### PR TITLE
Use env vars for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # bot
 
+## Configuration
+
+The bot reads required credentials from environment variables:
+
+- `DISCORD_TOKEN` – token for your Discord bot
+- `YOUTUBE_API_KEY` – API key used for YouTube searches
+
+Set these variables before running the bot.
+

--- a/bot
+++ b/bot
@@ -294,11 +294,19 @@ def ensure_ffmpeg() -> str:
         sys.exit(1)
 
 def get_config() -> BotConfig:
-    discord_token = "MTM4NzM4NzYwOTA0NjcxMjQyMA.GHt4TX.5QE-KnKMpES2WK5X5UkOLj5u6x_PIaARCCaKS4"
-    logger.info("Using working Discord bot token")
-    
-    youtube_api_key = "AIzaSyCpgM0W1DunsnEas0Fn_2h77r6nhS8rS7w"
-    
+    """Load configuration from environment variables."""
+    discord_token = os.getenv("DISCORD_TOKEN")
+    if discord_token:
+        logger.info("Discord token loaded from environment")
+    else:
+        logger.warning("DISCORD_TOKEN environment variable not set")
+
+    youtube_api_key = os.getenv("YOUTUBE_API_KEY")
+    if youtube_api_key:
+        logger.info("YouTube API key loaded from environment")
+    else:
+        logger.warning("YOUTUBE_API_KEY environment variable not set")
+
     menu_channel_id = None
     return BotConfig(
         discord_token=discord_token,


### PR DESCRIPTION
## Summary
- load Discord token and YouTube API key from environment variables
- remove hard-coded credentials
- document required environment variables

## Testing
- `python -m py_compile bot`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bec79bb08320a6a41667e9f81ec4