### PR TITLE
Fix missing play command wrapper

### DIFF
--- a/bot
+++ b/bot
@@ -1531,6 +1531,10 @@ class MusicBot(commands.Bot):
         embed.set_footer(text=f"Total songs in queue: {len(queue)}")
         await interaction.response.send_message(embed=embed)
 
+    async def play_command_impl(self, interaction: discord.Interaction, query: str):
+        """Wrapper for play command used by slash commands and UI."""
+        await self._play_command_impl(interaction, query)
+
     async def on_ready(self):
         """Called when bot is ready"""
         logger.info(f"{self.user} has connected to Discord, nya!")


### PR DESCRIPTION
## Summary
- add a `play_command_impl` wrapper on `MusicBot`

## Testing
- `python -m py_compile bot`

------
https://chatgpt.com/codex/tasks/task_e_6865b64695ec83208e95f561fe206954