### PR TITLE
Remove duplicate play command wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ The bot reads required credentials from environment variables:
 
 Set these variables before running the bot.
 
+Run the bot with `python bot.py`.
+

--- a/bot.py
+++ b/bot.py
@@ -1450,11 +1450,6 @@ class MusicBot(commands.Bot):
             
             logger.error(f"Play command crashed: {e}, nya!")
 
-
-    async def play_command_impl(self, interaction: discord.Interaction, query: str):
-        """Wrapper for play command used by slash commands and UI."""
-        await self._play_command_impl(interaction, query)
-
     async def on_ready(self):
         """Called when bot is ready"""
         logger.info(f"{self.user} has connected to Discord, nya!")


### PR DESCRIPTION
## Summary
- rename `bot` to `bot.py` for clarity
- remove redundant `play_command_impl` wrapper
- document how to run the bot

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d8f7af8c8320895f9a5ac0bd4a60