### PR TITLE
Implement mapping engine

### DIFF
--- a/InputToControllerMapper/MappingEngine.cs
+++ b/InputToControllerMapper/MappingEngine.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nefarius.ViGEm.Client;
+using Nefarius.ViGEm.Client.Targets.Xbox360;
+using System.Windows.Forms;
+
+namespace InputToControllerMapper
+{
+    public class MappingEngine : IDisposable
+    {
+        private readonly ViGEmClient client;
+        private readonly IXbox360Controller controller;
+        private MappingProfile profile = new MappingProfile();
+
+        public MappingEngine()
+        {
+            client = new ViGEmClient();
+            controller = client.CreateXbox360Controller();
+            controller.Connect();
+        }
+
+        public void LoadProfile(MappingProfile p)
+        {
+            profile = p;
+        }
+
+        public void LoadProfile(string path)
+        {
+            profile = MappingProfile.Load(path);
+        }
+
+        public void ProcessKeyEvent(Keys key, bool isDown)
+        {
+            float val = isDown ? 1f : 0f;
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.Key && string.Equals(m.Code, key.ToString(), StringComparison.OrdinalIgnoreCase)))
+            {
+                ApplyActions(map.Actions, val);
+            }
+        }
+
+        public void ProcessMouseButtonEvent(MouseButton button, bool isDown)
+        {
+            float val = isDown ? 1f : 0f;
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.MouseButton && string.Equals(m.Code, button.ToString(), StringComparison.OrdinalIgnoreCase)))
+            {
+                ApplyActions(map.Actions, val);
+            }
+        }
+
+        public void ProcessAnalogEvent(string source, float value)
+        {
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.Analog && string.Equals(m.Code, source, StringComparison.OrdinalIgnoreCase)))
+            {
+                ApplyActions(map.Actions, value);
+            }
+        }
+
+        private void ApplyActions(IEnumerable<ControllerAction> actions, float input)
+        {
+            foreach (var action in actions)
+            {
+                float val = input;
+                if (action.AnalogOptions != null)
+                {
+                    val = ApplyAnalogOptions(val, action.AnalogOptions);
+                }
+                SetControllerState(action, val);
+            }
+            controller.SubmitReport();
+        }
+
+        private static float ApplyAnalogOptions(float value, AnalogOptions opts)
+        {
+            if (Math.Abs(value) < opts.Deadzone)
+                return 0f;
+            value *= opts.Sensitivity;
+            value = Math.Clamp(value, -1f, 1f);
+            return opts.Curve switch
+            {
+                CurveType.Squared => MathF.Sign(value) * value * value,
+                _ => value
+            };
+        }
+
+        private void SetControllerState(ControllerAction action, float value)
+        {
+            switch (action.Element)
+            {
+                case ControllerElement.Button:
+                    controller.SetButtonState(Enum.Parse<Xbox360Button>(action.Target, true), value > 0.5f);
+                    break;
+                case ControllerElement.Axis:
+                    short axisVal = (short)(value * short.MaxValue);
+                    controller.SetAxisValue(Enum.Parse<Xbox360Axis>(action.Target, true), axisVal);
+                    break;
+                case ControllerElement.Trigger:
+                    byte trigVal = (byte)(Math.Clamp(value, 0f, 1f) * byte.MaxValue);
+                    controller.SetSliderValue(Enum.Parse<Xbox360Slider>(action.Target, true), trigVal);
+                    break;
+            }
+        }
+
+        public void Dispose()
+        {
+            controller.Disconnect();
+            controller.Dispose();
+            client.Dispose();
+        }
+    }
+}

--- a/InputToControllerMapper/MappingProfile.cs
+++ b/InputToControllerMapper/MappingProfile.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace InputToControllerMapper
+{
+    public enum InputType
+    {
+        Key,
+        MouseButton,
+        MouseMoveX,
+        MouseMoveY,
+        Analog
+    }
+
+    public enum MouseButton
+    {
+        Left,
+        Right,
+        Middle,
+        X1,
+        X2
+    }
+
+    public enum ControllerElement
+    {
+        Button,
+        Axis,
+        Trigger
+    }
+
+    public enum CurveType
+    {
+        Linear,
+        Squared
+    }
+
+    public class AnalogOptions
+    {
+        public float Deadzone { get; set; } = 0f;
+        public float Sensitivity { get; set; } = 1f;
+        public CurveType Curve { get; set; } = CurveType.Linear;
+    }
+
+    public class ControllerAction
+    {
+        public ControllerElement Element { get; set; }
+        public string Target { get; set; } = string.Empty;
+        public AnalogOptions? AnalogOptions { get; set; }
+    }
+
+    public class InputMapping
+    {
+        public InputType Type { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public List<ControllerAction> Actions { get; set; } = new();
+    }
+
+    public class MappingProfile
+    {
+        public string Name { get; set; } = "Default";
+        public List<InputMapping> Mappings { get; set; } = new();
+
+        public static MappingProfile Load(string path)
+        {
+            string json = File.ReadAllText(path);
+            var options = new JsonSerializerOptions
+            {
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            };
+            return JsonSerializer.Deserialize<MappingProfile>(json, options) ?? new MappingProfile();
+        }
+
+        public void Save(string path)
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            string json = JsonSerializer.Serialize(this, options);
+            File.WriteAllText(path, json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add profile data model for mapping configuration
- add mapping engine that loads profile JSON and processes input events

## Testing
- `dotnet build InputToControllerMapper/InputToControllerMapper.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d6d768348320960d1709feb38235