### PR TITLE
Add profile/settings management

### DIFF
--- a/InputToControllerMapper/Profile.cs
+++ b/InputToControllerMapper/Profile.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace InputToControllerMapper
+{
+    public class Profile
+    {
+        public const int CurrentVersion = 2;
+
+        public int Version { get; set; } = CurrentVersion;
+        public string Name { get; set; }
+        public Dictionary<string, string> KeyBindings { get; set; } = new Dictionary<string, string>();
+
+        public static Profile FromJson(string json)
+        {
+            using JsonDocument doc = JsonDocument.Parse(json);
+            return FromJsonElement(doc.RootElement);
+        }
+
+        public static Profile FromJsonElement(JsonElement element)
+        {
+            int version = element.TryGetProperty("Version", out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : 1;
+            string name = element.TryGetProperty("Name", out var n) ? n.GetString() : "Default";
+
+            var profile = new Profile { Name = name };
+
+            if (version == 1)
+            {
+                if (element.TryGetProperty("Bindings", out var b) && b.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (var prop in b.EnumerateObject())
+                        profile.KeyBindings[prop.Name] = prop.Value.GetString();
+                }
+            }
+            else
+            {
+                if (element.TryGetProperty("KeyBindings", out var b) && b.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (var prop in b.EnumerateObject())
+                        profile.KeyBindings[prop.Name] = prop.Value.GetString();
+                }
+            }
+
+            profile.Version = CurrentVersion;
+            return profile;
+        }
+    }
+}

--- a/InputToControllerMapper/ProfileManager.cs
+++ b/InputToControllerMapper/ProfileManager.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace InputToControllerMapper
+{
+    public class ProfileChangedEventArgs : EventArgs
+    {
+        public Profile Profile { get; }
+        public ProfileChangedEventArgs(Profile profile) { Profile = profile; }
+    }
+
+    public class ProfileManager
+    {
+        private readonly string profilesPath;
+        private readonly Dictionary<string, Profile> profiles = new();
+        private Profile activeProfile;
+
+        public event EventHandler<ProfileChangedEventArgs> ProfileChanged;
+
+        public ProfileManager(string path)
+        {
+            profilesPath = path;
+            Directory.CreateDirectory(profilesPath);
+            LoadProfiles();
+        }
+
+        public IEnumerable<Profile> All => profiles.Values;
+
+        public Profile ActiveProfile => activeProfile;
+
+        private void LoadProfiles()
+        {
+            profiles.Clear();
+            foreach (string file in Directory.GetFiles(profilesPath, "*.json"))
+            {
+                try
+                {
+                    string json = File.ReadAllText(file);
+                    Profile profile = Profile.FromJson(json);
+                    profile.Name = Path.GetFileNameWithoutExtension(file);
+                    profiles[profile.Name] = profile;
+                    SaveProfile(profile); // ensure up to date
+                }
+                catch { }
+            }
+
+            if (!profiles.TryGetValue("Default", out activeProfile))
+            {
+                activeProfile = new Profile { Name = "Default" };
+                SaveProfile(activeProfile);
+                profiles["Default"] = activeProfile;
+            }
+        }
+
+        public void SaveProfile(Profile profile)
+        {
+            string path = Path.Combine(profilesPath, profile.Name + ".json");
+            string json = JsonSerializer.Serialize(profile, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(path, json);
+        }
+
+        public bool SetActiveProfile(string name)
+        {
+            if (profiles.TryGetValue(name, out var p))
+            {
+                activeProfile = p;
+                ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(p));
+                return true;
+            }
+            return false;
+        }
+
+        public Profile GetProfile(string name)
+        {
+            profiles.TryGetValue(name, out var p);
+            return p;
+        }
+    }
+}

--- a/InputToControllerMapper/SettingsManager.cs
+++ b/InputToControllerMapper/SettingsManager.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace InputToControllerMapper
+{
+    public class Settings
+    {
+        public string ActiveProfile { get; set; } = "Default";
+        public Dictionary<string, string> ProcessProfiles { get; set; } = new Dictionary<string, string>();
+    }
+
+    public class SettingsManager
+    {
+        private readonly string filePath;
+        private Settings settings;
+
+        public event EventHandler SettingsChanged;
+
+        public SettingsManager(string path)
+        {
+            filePath = path;
+            Load();
+        }
+
+        public Settings Current => settings;
+
+        public void Load()
+        {
+            if (File.Exists(filePath))
+            {
+                string json = File.ReadAllText(filePath);
+                settings = JsonSerializer.Deserialize<Settings>(json) ?? new Settings();
+            }
+            else
+            {
+                settings = new Settings();
+                Save();
+            }
+        }
+
+        public void Save()
+        {
+            string json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(filePath, json);
+            SettingsChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public string GetProfileForProcess(string processName)
+        {
+            return settings.ProcessProfiles.TryGetValue(processName, out var profile) ? profile : settings.ActiveProfile;
+        }
+
+        public void SetProfileForProcess(string processName, string profile)
+        {
+            settings.ProcessProfiles[processName] = profile;
+            Save();
+        }
+
+        public void SetActiveProfile(string name)
+        {
+            settings.ActiveProfile = name;
+            Save();
+        }
+
+        public string GetProfileForForegroundProcess()
+        {
+            try
+            {
+                using Process p = Process.GetCurrentProcess();
+                string name = p.ProcessName;
+                return GetProfileForProcess(name);
+            }
+            catch
+            {
+                return settings.ActiveProfile;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Profile` class with schema migration logic
- add `ProfileManager` to load profiles and track the active one
- add `SettingsManager` for per-process profile selection

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d6ed42f4832093484a32eb0a49a2