### PR TITLE
Add main window and tray stub UI

### DIFF
--- a/InputToControllerMapper/MainForm.cs
+++ b/InputToControllerMapper/MainForm.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace InputToControllerMapper
+{
+    public class MainForm : Form
+    {
+        private ListBox profileList;
+        private DataGridView mappingGrid;
+        private GroupBox inputGroup;
+        private GroupBox outputGroup;
+        private TrayIcon tray;
+
+        public MainForm()
+        {
+            Text = "Input To Controller Mapper";
+            Size = new Size(800, 600);
+
+            profileList = new ListBox { Dock = DockStyle.Left, Width = 150 };
+            Controls.Add(profileList);
+
+            mappingGrid = new DataGridView { Dock = DockStyle.Fill, AllowUserToAddRows = false };
+            mappingGrid.Columns.Add("Input", "Input");
+            mappingGrid.Columns.Add("Output", "Controller Output");
+            Controls.Add(mappingGrid);
+
+            inputGroup = new GroupBox { Text = "Input State", Dock = DockStyle.Bottom, Height = 80 };
+            outputGroup = new GroupBox { Text = "Output State", Dock = DockStyle.Bottom, Height = 80 };
+            Controls.Add(outputGroup);
+            Controls.Add(inputGroup);
+
+            FormClosing += OnFormClosing;
+            tray = new TrayIcon(this);
+        }
+
+        private void OnFormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (e.CloseReason == CloseReason.UserClosing)
+            {
+                e.Cancel = true;
+                Hide();
+                tray.ShowHideNotification();
+            }
+        }
+
+        public void UpdateInputState(string text)
+        {
+            inputGroup.Text = "Input State: " + text;
+        }
+
+        public void UpdateOutputState(string text)
+        {
+            outputGroup.Text = "Output State: " + text;
+        }
+    }
+}

--- a/InputToControllerMapper/Program.cs
+++ b/InputToControllerMapper/Program.cs
@@ -12,8 +12,7 @@ namespace InputToControllerMapper
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            InputCaptureForm mainForm = new InputCaptureForm();
-            mainForm.WindowState = FormWindowState.Minimized;
+            MainForm mainForm = new MainForm();
             Application.Run(mainForm);
         }
     }

--- a/InputToControllerMapper/TrayIcon.cs
+++ b/InputToControllerMapper/TrayIcon.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace InputToControllerMapper
+{
+    public class TrayIcon : IDisposable
+    {
+        private readonly NotifyIcon notifyIcon;
+        private readonly Form mainForm;
+
+        public TrayIcon(Form form)
+        {
+            mainForm = form;
+            notifyIcon = new NotifyIcon
+            {
+                Icon = SystemIcons.Application,
+                Text = "Input To Controller Mapper",
+                Visible = true
+            };
+            notifyIcon.DoubleClick += (s, e) => ShowMainForm();
+
+            var menu = new ContextMenuStrip();
+            menu.Items.Add("Show", null, (s, e) => ShowMainForm());
+            menu.Items.Add("Exit", null, (s, e) => Application.Exit());
+            notifyIcon.ContextMenuStrip = menu;
+        }
+
+        private void ShowMainForm()
+        {
+            if (mainForm.Visible)
+            {
+                mainForm.WindowState = FormWindowState.Normal;
+                mainForm.Activate();
+            }
+            else
+            {
+                mainForm.Show();
+            }
+        }
+
+        public void ShowHideNotification()
+        {
+            notifyIcon.BalloonTipTitle = "Input To Controller Mapper";
+            notifyIcon.BalloonTipText = "Application is still running";
+            notifyIcon.ShowBalloonTip(1000);
+        }
+
+        public void Dispose()
+        {
+            notifyIcon.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `MainForm` WinForms window for listing profiles and mapping inputs to controller outputs
- add `TrayIcon` to support minimize-to-tray behavior
- update `Program` to start `MainForm`

## Testing
- `dotnet build InputToControllerMapper/InputToControllerMapper.csproj -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867d6f460dc83209c6b812d0569795f