### PR TITLE
Add core mapping engine

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Core/IVirtualController.cs
+++ b/Core/IVirtualController.cs
@@ -1,0 +1,14 @@
+namespace Core
+{
+    /// <summary>
+    /// Abstracts the controller implementation used by <see cref="MappingEngine"/>.
+    /// </summary>
+    public interface IVirtualController
+    {
+        void SetButtonState(string button, bool pressed);
+        void SetAxisValue(string axis, short value);
+        void SetTriggerValue(string trigger, byte value);
+        void SetDPadState(string direction, bool pressed);
+        void Submit();
+    }
+}

--- a/Core/InputEvent.cs
+++ b/Core/InputEvent.cs
@@ -1,0 +1,20 @@
+namespace Core
+{
+    /// <summary>
+    /// Generic input event used by <see cref="MappingEngine"/>
+    /// to represent keyboard, mouse and analog events.
+    /// </summary>
+    public class InputEvent
+    {
+        public InputType Type { get; }
+        public string Code { get; }
+        public float Value { get; }
+
+        public InputEvent(InputType type, string code, float value)
+        {
+            Type = type;
+            Code = code;
+            Value = value;
+        }
+    }
+}

--- a/Core/MappingEngine.cs
+++ b/Core/MappingEngine.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Core
+{
+    /// <summary>
+    /// Central class that translates input events into controller state.
+    /// </summary>
+    public class MappingEngine
+    {
+        private readonly MouseToStickMapper mouseMapper = new();
+        private Profile profile = new Profile();
+
+        private readonly Dictionary<string, bool> buttonStates = new();
+        private readonly Dictionary<string, float> axisStates = new();
+        private readonly Dictionary<string, float> triggerStates = new();
+        private readonly Dictionary<string, bool> dpadStates = new();
+
+        private int mouseDeltaX;
+        private int mouseDeltaY;
+
+        /// <summary>Apply a new profile.</summary>
+        public void ApplyProfile(Profile profile) => this.profile = profile;
+
+        /// <summary>Handle an incoming input event.</summary>
+        public void ProcessInputEvent(InputEvent e)
+        {
+            if (e.Type == InputType.MouseMoveX)
+                mouseDeltaX += (int)e.Value;
+            else if (e.Type == InputType.MouseMoveY)
+                mouseDeltaY += (int)e.Value;
+            else
+                ProcessDirectEvent(e.Type, e.Code, e.Value);
+        }
+
+        private void ProcessDirectEvent(InputType type, string code, float value)
+        {
+            foreach (var map in profile.Mappings.Where(m => m.Type == type &&
+                        string.Equals(m.Code, code, StringComparison.OrdinalIgnoreCase)))
+            {
+                ApplyActions(map.Actions, value);
+            }
+        }
+
+        private void ApplyMouseMappings()
+        {
+            if (mouseDeltaX == 0 && mouseDeltaY == 0)
+                return;
+
+            (short x, short y) = mouseMapper.Map(mouseDeltaX, mouseDeltaY);
+            float fx = x / 32767f;
+            float fy = y / 32767f;
+
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.MouseMoveX))
+                ApplyActions(map.Actions, fx);
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.MouseMoveY))
+                ApplyActions(map.Actions, fy);
+
+            mouseDeltaX = 0;
+            mouseDeltaY = 0;
+        }
+
+        private void ApplyActions(IEnumerable<ControllerAction> actions, float input)
+        {
+            foreach (var action in actions)
+            {
+                float val = input;
+                if (action.AnalogOptions != null)
+                    val = ApplyAnalogOptions(val, action.AnalogOptions);
+
+                switch (action.Element)
+                {
+                    case ControllerElement.Button:
+                        buttonStates[action.Target] = val > 0.5f;
+                        break;
+                    case ControllerElement.Axis:
+                        axisStates[action.Target] = Math.Clamp(val, -1f, 1f);
+                        break;
+                    case ControllerElement.Trigger:
+                        triggerStates[action.Target] = Math.Clamp(val, 0f, 1f);
+                        break;
+                    case ControllerElement.DPad:
+                        dpadStates[action.Target] = val > 0.5f;
+                        break;
+                }
+            }
+        }
+
+        private static float ApplyAnalogOptions(float value, AnalogOptions opts)
+        {
+            if (Math.Abs(value) < opts.Deadzone)
+                return 0f;
+            value *= opts.Sensitivity;
+            value = Math.Clamp(value, -1f, 1f);
+            return opts.Curve switch
+            {
+                CurveType.Squared => MathF.Sign(value) * value * value,
+                _ => value
+            };
+        }
+
+        /// <summary>
+        /// Update the provided virtual controller with the current computed state.
+        /// </summary>
+        public void UpdateControllerState(IVirtualController ctrl)
+        {
+            ApplyMouseMappings();
+
+            foreach (var kv in buttonStates)
+                ctrl.SetButtonState(kv.Key, kv.Value);
+            foreach (var kv in axisStates)
+                ctrl.SetAxisValue(kv.Key, (short)(kv.Value * short.MaxValue));
+            foreach (var kv in triggerStates)
+                ctrl.SetTriggerValue(kv.Key, (byte)(kv.Value * byte.MaxValue));
+            foreach (var kv in dpadStates)
+                ctrl.SetDPadState(kv.Key, kv.Value);
+
+            ctrl.Submit();
+        }
+    }
+}

--- a/Core/MouseToStickMapper.cs
+++ b/Core/MouseToStickMapper.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace Core
+{
+    public enum StickCurveShape
+    {
+        Linear,
+        Exponential,
+        DualZone
+    }
+
+    /// <summary>
+    /// Translates raw mouse movement into normalized stick values.
+    /// </summary>
+    public class MouseToStickMapper
+    {
+        public float SensitivityX { get; set; } = 1f;
+        public float SensitivityY { get; set; } = 1f;
+        public float Deadzone { get; set; } = 0f;
+        public float Acceleration { get; set; } = 0f;
+        public float Smoothing { get; set; } = 0f;
+        public bool InvertY { get; set; }
+        public StickCurveShape Curve { get; set; } = StickCurveShape.Linear;
+        public float Exponent { get; set; } = 1.5f;          // used for Exponential and DualZone curves
+        public float OuterExponent { get; set; } = 1.0f;      // used for DualZone curves
+        public float DualZoneThreshold { get; set; } = 0.5f;  // 0..1
+
+        private float smoothX;
+        private float smoothY;
+
+        /// <summary>
+        /// Process mouse delta and return stick axis values in range -32767..32767.
+        /// </summary>
+        public (short X, short Y) Map(int deltaX, int deltaY)
+        {
+            float x = ProcessAxis(deltaX, SensitivityX, ref smoothX);
+            float y = ProcessAxis(deltaY, SensitivityY, ref smoothY);
+
+            if (InvertY)
+                y = -y;
+
+            short sx = (short)Math.Clamp(x * 32767f, -32767f, 32767f);
+            short sy = (short)Math.Clamp(y * 32767f, -32767f, 32767f);
+            return (sx, sy);
+        }
+
+        private float ProcessAxis(int delta, float sensitivity, ref float smooth)
+        {
+            float value = delta * sensitivity;
+
+            if (Acceleration > 0f)
+                value *= 1f + MathF.Abs(value) * Acceleration;
+
+            if (Smoothing > 0f)
+            {
+                smooth += (value - smooth) * Smoothing;
+                value = smooth;
+            }
+
+            float sign = MathF.Sign(value);
+            float magnitude = MathF.Abs(value);
+
+            if (magnitude < Deadzone)
+                return 0f;
+
+            magnitude = (magnitude - Deadzone) / (1f - Deadzone);
+            magnitude = ApplyCurve(magnitude);
+
+            return sign * magnitude;
+        }
+
+        private float ApplyCurve(float value)
+        {
+            value = MathF.Min(MathF.Max(value, 0f), 1f);
+
+            switch (Curve)
+            {
+                case StickCurveShape.Linear:
+                    return value;
+                case StickCurveShape.Exponential:
+                    return MathF.Pow(value, Exponent);
+                case StickCurveShape.DualZone:
+                    if (value < DualZoneThreshold)
+                    {
+                        float inner = value / DualZoneThreshold;
+                        return MathF.Pow(inner, Exponent) * DualZoneThreshold;
+                    }
+                    else
+                    {
+                        float outer = (value - DualZoneThreshold) / (1f - DualZoneThreshold);
+                        return MathF.Pow(outer, OuterExponent) * (1f - DualZoneThreshold) + DualZoneThreshold;
+                    }
+                default:
+                    return value;
+            }
+        }
+    }
+}

--- a/Core/Profile.cs
+++ b/Core/Profile.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Core
+{
+    public enum InputType
+    {
+        Key,
+        MouseButton,
+        MouseMoveX,
+        MouseMoveY,
+        Analog
+    }
+
+    public enum MouseButton
+    {
+        Left,
+        Right,
+        Middle,
+        X1,
+        X2
+    }
+
+    public enum ControllerElement
+    {
+        Button,
+        Axis,
+        Trigger,
+        DPad
+    }
+
+    public enum CurveType
+    {
+        Linear,
+        Squared
+    }
+
+    public class AnalogOptions
+    {
+        public float Deadzone { get; set; } = 0f;
+        public float Sensitivity { get; set; } = 1f;
+        public CurveType Curve { get; set; } = CurveType.Linear;
+    }
+
+    public class ControllerAction
+    {
+        public ControllerElement Element { get; set; }
+        public string Target { get; set; } = string.Empty;
+        public AnalogOptions? AnalogOptions { get; set; }
+    }
+
+    public class InputMapping
+    {
+        public InputType Type { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public List<ControllerAction> Actions { get; set; } = new();
+    }
+
+    public class Profile
+    {
+        public string Name { get; set; } = "Default";
+        public List<InputMapping> Mappings { get; set; } = new();
+
+        public static Profile Load(string path)
+        {
+            string json = File.ReadAllText(path);
+            var options = new JsonSerializerOptions
+            {
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            };
+            return JsonSerializer.Deserialize<Profile>(json, options) ?? new Profile();
+        }
+
+        public void Save(string path)
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            string json = JsonSerializer.Serialize(this, options);
+            File.WriteAllText(path, json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create a Core library project
- implement `MappingEngine` for translating input events to controller state
- define `InputEvent`, `Profile`, and `IVirtualController`
- include reusable `MouseToStickMapper`

## Testing
- `dotnet build Core/Core.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc5ea44c8320a6bb0bae16bc07c8