### PR TITLE
Implement advanced Wooting analog handler

### DIFF
--- a/InputToControllerMapper/InputCaptureForm.cs
+++ b/InputToControllerMapper/InputCaptureForm.cs
@@ -68,12 +68,13 @@ namespace InputToControllerMapper
 
             try
             {
-                wootingHandler = new WootingAnalogHandler(v =>
+                wootingHandler = new WootingAnalogHandler();
+                wootingHandler.AnalogValueChanged += (_, value) =>
                 {
-                    byte val = (byte)(v * 255);
+                    byte val = (byte)(Math.Clamp(value, 0f, 1f) * 255);
                     controller.SetSliderValue(Xbox360Slider.LeftTrigger, val);
                     controller.SubmitReport();
-                });
+                };
                 wootingPanel.BackColor = Color.Green;
                 Log("Wooting ready");
             }


### PR DESCRIPTION
## Summary
- add new implementation of `WootingAnalogHandler` using P/Invoke to call the wrapper DLL
- support analog value polling on a background thread with DKS and rapid‑trigger logic
- adapt `InputCaptureForm` to subscribe to new events

## Testing
- `dotnet build InputToControllerMapper/InputToControllerMapper.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc5973ec8320a1e84a04cd850789