### PR TITLE
Implement core profile manager

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/Core/IVirtualController.cs
+++ b/Core/IVirtualController.cs
@@ -1,0 +1,14 @@
+namespace Core
+{
+    /// <summary>
+    /// Abstracts the controller implementation used by <see cref="MappingEngine"/>.
+    /// </summary>
+    public interface IVirtualController
+    {
+        void SetButtonState(string button, bool pressed);
+        void SetAxisValue(string axis, short value);
+        void SetTriggerValue(string trigger, byte value);
+        void SetDPadState(string direction, bool pressed);
+        void Submit();
+    }
+}

--- a/Core/InputEvent.cs
+++ b/Core/InputEvent.cs
@@ -1,0 +1,20 @@
+namespace Core
+{
+    /// <summary>
+    /// Generic input event used by <see cref="MappingEngine"/>
+    /// to represent keyboard, mouse and analog events.
+    /// </summary>
+    public class InputEvent
+    {
+        public InputType Type { get; }
+        public string Code { get; }
+        public float Value { get; }
+
+        public InputEvent(InputType type, string code, float value)
+        {
+            Type = type;
+            Code = code;
+            Value = value;
+        }
+    }
+}

--- a/Core/MappingEngine.cs
+++ b/Core/MappingEngine.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Core
+{
+    /// <summary>
+    /// Central class that translates input events into controller state.
+    /// </summary>
+    public class MappingEngine
+    {
+        private readonly MouseToStickMapper mouseMapper = new();
+        private Profile profile = new Profile();
+
+        private readonly Dictionary<string, bool> buttonStates = new();
+        private readonly Dictionary<string, float> axisStates = new();
+        private readonly Dictionary<string, float> triggerStates = new();
+        private readonly Dictionary<string, bool> dpadStates = new();
+
+        private int mouseDeltaX;
+        private int mouseDeltaY;
+
+        /// <summary>Apply a new profile.</summary>
+        public void ApplyProfile(Profile profile) => this.profile = profile;
+
+        /// <summary>Handle an incoming input event.</summary>
+        public void ProcessInputEvent(InputEvent e)
+        {
+            if (e.Type == InputType.MouseMoveX)
+                mouseDeltaX += (int)e.Value;
+            else if (e.Type == InputType.MouseMoveY)
+                mouseDeltaY += (int)e.Value;
+            else
+                ProcessDirectEvent(e.Type, e.Code, e.Value);
+        }
+
+        private void ProcessDirectEvent(InputType type, string code, float value)
+        {
+            foreach (var map in profile.Mappings.Where(m => m.Type == type &&
+                        string.Equals(m.Code, code, StringComparison.OrdinalIgnoreCase)))
+            {
+                ApplyActions(map.Actions, value);
+            }
+        }
+
+        private void ApplyMouseMappings()
+        {
+            if (mouseDeltaX == 0 && mouseDeltaY == 0)
+                return;
+
+            (short x, short y) = mouseMapper.Map(mouseDeltaX, mouseDeltaY);
+            float fx = x / 32767f;
+            float fy = y / 32767f;
+
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.MouseMoveX))
+                ApplyActions(map.Actions, fx);
+            foreach (var map in profile.Mappings.Where(m => m.Type == InputType.MouseMoveY))
+                ApplyActions(map.Actions, fy);
+
+            mouseDeltaX = 0;
+            mouseDeltaY = 0;
+        }
+
+        private void ApplyActions(IEnumerable<ControllerAction> actions, float input)
+        {
+            foreach (var action in actions)
+            {
+                float val = input;
+                if (action.AnalogOptions != null)
+                    val = ApplyAnalogOptions(val, action.AnalogOptions);
+
+                switch (action.Element)
+                {
+                    case ControllerElement.Button:
+                        buttonStates[action.Target] = val > 0.5f;
+                        break;
+                    case ControllerElement.Axis:
+                        axisStates[action.Target] = Math.Clamp(val, -1f, 1f);
+                        break;
+                    case ControllerElement.Trigger:
+                        triggerStates[action.Target] = Math.Clamp(val, 0f, 1f);
+                        break;
+                    case ControllerElement.DPad:
+                        dpadStates[action.Target] = val > 0.5f;
+                        break;
+                }
+            }
+        }
+
+        private static float ApplyAnalogOptions(float value, AnalogOptions opts)
+        {
+            if (Math.Abs(value) < opts.Deadzone)
+                return 0f;
+            value *= opts.Sensitivity;
+            value = Math.Clamp(value, -1f, 1f);
+            return opts.Curve switch
+            {
+                CurveType.Squared => MathF.Sign(value) * value * value,
+                _ => value
+            };
+        }
+
+        /// <summary>
+        /// Update the provided virtual controller with the current computed state.
+        /// </summary>
+        public void UpdateControllerState(IVirtualController ctrl)
+        {
+            ApplyMouseMappings();
+
+            foreach (var kv in buttonStates)
+                ctrl.SetButtonState(kv.Key, kv.Value);
+            foreach (var kv in axisStates)
+                ctrl.SetAxisValue(kv.Key, (short)(kv.Value * short.MaxValue));
+            foreach (var kv in triggerStates)
+                ctrl.SetTriggerValue(kv.Key, (byte)(kv.Value * byte.MaxValue));
+            foreach (var kv in dpadStates)
+                ctrl.SetDPadState(kv.Key, kv.Value);
+
+            ctrl.Submit();
+        }
+    }
+}

--- a/Core/MouseToStickMapper.cs
+++ b/Core/MouseToStickMapper.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace Core
+{
+    public enum StickCurveShape
+    {
+        Linear,
+        Exponential,
+        DualZone
+    }
+
+    /// <summary>
+    /// Translates raw mouse movement into normalized stick values.
+    /// </summary>
+    public class MouseToStickMapper
+    {
+        public float SensitivityX { get; set; } = 1f;
+        public float SensitivityY { get; set; } = 1f;
+        public float Deadzone { get; set; } = 0f;
+        public float Acceleration { get; set; } = 0f;
+        public float Smoothing { get; set; } = 0f;
+        public bool InvertY { get; set; }
+        public StickCurveShape Curve { get; set; } = StickCurveShape.Linear;
+        public float Exponent { get; set; } = 1.5f;          // used for Exponential and DualZone curves
+        public float OuterExponent { get; set; } = 1.0f;      // used for DualZone curves
+        public float DualZoneThreshold { get; set; } = 0.5f;  // 0..1
+
+        private float smoothX;
+        private float smoothY;
+
+        /// <summary>
+        /// Process mouse delta and return stick axis values in range -32767..32767.
+        /// </summary>
+        public (short X, short Y) Map(int deltaX, int deltaY)
+        {
+            float x = ProcessAxis(deltaX, SensitivityX, ref smoothX);
+            float y = ProcessAxis(deltaY, SensitivityY, ref smoothY);
+
+            if (InvertY)
+                y = -y;
+
+            short sx = (short)Math.Clamp(x * 32767f, -32767f, 32767f);
+            short sy = (short)Math.Clamp(y * 32767f, -32767f, 32767f);
+            return (sx, sy);
+        }
+
+        private float ProcessAxis(int delta, float sensitivity, ref float smooth)
+        {
+            float value = delta * sensitivity;
+
+            if (Acceleration > 0f)
+                value *= 1f + MathF.Abs(value) * Acceleration;
+
+            if (Smoothing > 0f)
+            {
+                smooth += (value - smooth) * Smoothing;
+                value = smooth;
+            }
+
+            float sign = MathF.Sign(value);
+            float magnitude = MathF.Abs(value);
+
+            if (magnitude < Deadzone)
+                return 0f;
+
+            magnitude = (magnitude - Deadzone) / (1f - Deadzone);
+            magnitude = ApplyCurve(magnitude);
+
+            return sign * magnitude;
+        }
+
+        private float ApplyCurve(float value)
+        {
+            value = MathF.Min(MathF.Max(value, 0f), 1f);
+
+            switch (Curve)
+            {
+                case StickCurveShape.Linear:
+                    return value;
+                case StickCurveShape.Exponential:
+                    return MathF.Pow(value, Exponent);
+                case StickCurveShape.DualZone:
+                    if (value < DualZoneThreshold)
+                    {
+                        float inner = value / DualZoneThreshold;
+                        return MathF.Pow(inner, Exponent) * DualZoneThreshold;
+                    }
+                    else
+                    {
+                        float outer = (value - DualZoneThreshold) / (1f - DualZoneThreshold);
+                        return MathF.Pow(outer, OuterExponent) * (1f - DualZoneThreshold) + DualZoneThreshold;
+                    }
+                default:
+                    return value;
+            }
+        }
+    }
+}

--- a/Core/Profile.cs
+++ b/Core/Profile.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Controller.Core
+{
+    public class Profile
+    {
+        public const int CurrentVersion = 1;
+
+        public int Version { get; set; } = CurrentVersion;
+        public string Name { get; set; } = "Default";
+        public Dictionary<string, string> KeyBindings { get; set; } = new();
+
+        public static Profile FromJson(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+            return FromJsonElement(doc.RootElement);
+        }
+
+        public static Profile FromJsonElement(JsonElement element)
+        {
+            var profile = new Profile
+            {
+                Version = element.TryGetProperty("Version", out var v) && v.ValueKind == JsonValueKind.Number
+                    ? v.GetInt32() : CurrentVersion,
+                Name = element.TryGetProperty("Name", out var n) ? n.GetString() ?? "Default" : "Default"
+            };
+
+            if (element.TryGetProperty("KeyBindings", out var bindings) && bindings.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in bindings.EnumerateObject())
+                    profile.KeyBindings[prop.Name] = prop.Value.GetString() ?? string.Empty;
+            }
+
+            profile.Version = CurrentVersion;
+            return profile;
+        }
+    }
+}

--- a/Core/ProfileManager.cs
+++ b/Core/ProfileManager.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Controller.Core
+{
+    public class ProfileChangedEventArgs : EventArgs
+    {
+        public Profile Profile { get; }
+        public ProfileChangedEventArgs(Profile profile) => Profile = profile;
+    }
+
+    public class ProfileManager
+    {
+        private readonly string configDir;
+        private readonly string profilesDir;
+        private readonly string settingsPath;
+        private readonly Dictionary<string, Profile> profiles = new();
+        private Profile? current;
+        private ProfileSettings settings = new();
+
+        public event EventHandler<ProfileChangedEventArgs>? ProfileChanged;
+        public event EventHandler? ProfileListChanged;
+
+        public ProfileManager(string appName)
+        {
+            configDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName);
+            profilesDir = Path.Combine(configDir, "profiles");
+            settingsPath = Path.Combine(configDir, "profiles.json");
+            Directory.CreateDirectory(profilesDir);
+            Load();
+        }
+
+        public IEnumerable<Profile> Profiles => profiles.Values;
+        public Profile CurrentProfile => current ?? throw new InvalidOperationException("No profile loaded");
+
+        private void Load()
+        {
+            if (File.Exists(settingsPath))
+            {
+                string json = File.ReadAllText(settingsPath);
+                settings = JsonSerializer.Deserialize<ProfileSettings>(json) ?? new ProfileSettings();
+            }
+            else
+            {
+                settings = new ProfileSettings();
+                SaveSettings();
+            }
+
+            profiles.Clear();
+            foreach (var file in Directory.GetFiles(profilesDir, "*.json"))
+            {
+                try
+                {
+                    string json = File.ReadAllText(file);
+                    var profile = Profile.FromJson(json);
+                    profile.Name = Path.GetFileNameWithoutExtension(file);
+                    profiles[profile.Name] = profile;
+                }
+                catch { }
+            }
+
+            if (!profiles.TryGetValue(settings.CurrentProfile, out current))
+            {
+                if (profiles.Count > 0)
+                {
+                    current = profiles.Values.First();
+                    settings.CurrentProfile = current.Name;
+                }
+                else
+                {
+                    current = new Profile { Name = settings.CurrentProfile };
+                    profiles[current.Name] = current;
+                    SaveProfile(current);
+                }
+                SaveSettings();
+            }
+        }
+
+        private void SaveSettings()
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            string json = JsonSerializer.Serialize(settings, options);
+            Directory.CreateDirectory(configDir);
+            File.WriteAllText(settingsPath, json);
+        }
+
+        public void SaveProfile(Profile profile)
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            string json = JsonSerializer.Serialize(profile, options);
+            File.WriteAllText(Path.Combine(profilesDir, profile.Name + ".json"), json);
+        }
+
+        public bool AddProfile(Profile profile)
+        {
+            if (profiles.ContainsKey(profile.Name))
+                return false;
+            profiles[profile.Name] = profile;
+            SaveProfile(profile);
+            ProfileListChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+
+        public bool DeleteProfile(string name)
+        {
+            if (!profiles.Remove(name))
+                return false;
+            var file = Path.Combine(profilesDir, name + ".json");
+            if (File.Exists(file))
+                File.Delete(file);
+            if (settings.CurrentProfile == name)
+            {
+                settings.CurrentProfile = profiles.Keys.FirstOrDefault() ?? "Default";
+                SetCurrentProfile(settings.CurrentProfile);
+            }
+            SaveSettings();
+            ProfileListChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+
+        public bool CloneProfile(string sourceName, string newName)
+        {
+            if (!profiles.TryGetValue(sourceName, out var src) || profiles.ContainsKey(newName))
+                return false;
+            var clone = JsonSerializer.Deserialize<Profile>(JsonSerializer.Serialize(src)) ?? new Profile();
+            clone.Name = newName;
+            return AddProfile(clone);
+        }
+
+        public bool SetCurrentProfile(string name)
+        {
+            if (!profiles.TryGetValue(name, out var p))
+                return false;
+            current = p;
+            settings.CurrentProfile = name;
+            SaveSettings();
+            ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(p));
+            return true;
+        }
+
+        public string ResolveProfile(string process, string windowTitle)
+        {
+            foreach (var rule in settings.AppProfiles)
+            {
+                if (!string.IsNullOrEmpty(rule.ProcessName) && process.Equals(rule.ProcessName, StringComparison.OrdinalIgnoreCase))
+                    return rule.ProfileName;
+                if (!string.IsNullOrEmpty(rule.WindowTitleContains) && !string.IsNullOrEmpty(windowTitle) && windowTitle.Contains(rule.WindowTitleContains, StringComparison.OrdinalIgnoreCase))
+                    return rule.ProfileName;
+            }
+            return settings.CurrentProfile;
+        }
+
+        public void AutoSwitch(string process, string windowTitle)
+        {
+            var profile = ResolveProfile(process, windowTitle);
+            if (profile != CurrentProfile.Name)
+                SetCurrentProfile(profile);
+        }
+
+        public void SetProcessProfile(string process, string profileName)
+        {
+            var rule = settings.AppProfiles.FirstOrDefault(r => r.ProcessName?.Equals(process, StringComparison.OrdinalIgnoreCase) == true);
+            if (rule == null)
+            {
+                rule = new AppProfileRule { ProcessName = process, ProfileName = profileName };
+                settings.AppProfiles.Add(rule);
+            }
+            else
+            {
+                rule.ProfileName = profileName;
+            }
+            SaveSettings();
+        }
+
+        public void SetWindowProfile(string title, string profileName)
+        {
+            var rule = settings.AppProfiles.FirstOrDefault(r => r.WindowTitleContains?.Equals(title, StringComparison.OrdinalIgnoreCase) == true);
+            if (rule == null)
+            {
+                rule = new AppProfileRule { WindowTitleContains = title, ProfileName = profileName };
+                settings.AppProfiles.Add(rule);
+            }
+            else
+            {
+                rule.ProfileName = profileName;
+            }
+            SaveSettings();
+        }
+    }
+
+    public class ProfileSettings
+    {
+        public string CurrentProfile { get; set; } = "Default";
+        public List<AppProfileRule> AppProfiles { get; set; } = new();
+    }
+
+    public class AppProfileRule
+    {
+        public string? ProcessName { get; set; }
+        public string? WindowTitleContains { get; set; }
+        public string ProfileName { get; set; } = "Default";
+    }
+}

--- a/Core/ProfileManager.cs
+++ b/Core/ProfileManager.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 
-namespace Controller.Core
+namespace Core
 {
     public class ProfileChangedEventArgs : EventArgs
     {
@@ -57,8 +57,7 @@ namespace Controller.Core
             {
                 try
                 {
-                    string json = File.ReadAllText(file);
-                    var profile = Profile.FromJson(json);
+                    var profile = Profile.Load(file);
                     profile.Name = Path.GetFileNameWithoutExtension(file);
                     profiles[profile.Name] = profile;
                 }
@@ -92,9 +91,8 @@ namespace Controller.Core
 
         public void SaveProfile(Profile profile)
         {
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            string json = JsonSerializer.Serialize(profile, options);
-            File.WriteAllText(Path.Combine(profilesDir, profile.Name + ".json"), json);
+            string path = Path.Combine(profilesDir, profile.Name + ".json");
+            profile.Save(path);
         }
 
         public bool AddProfile(Profile profile)
@@ -128,7 +126,8 @@ namespace Controller.Core
         {
             if (!profiles.TryGetValue(sourceName, out var src) || profiles.ContainsKey(newName))
                 return false;
-            var clone = JsonSerializer.Deserialize<Profile>(JsonSerializer.Serialize(src)) ?? new Profile();
+            string path = Path.Combine(profilesDir, sourceName + ".json");
+            var clone = Profile.Load(path);
             clone.Name = newName;
             return AddProfile(clone);
         }

--- a/Core/ProfileManager.cs
+++ b/Core/ProfileManager.cs
@@ -34,6 +34,9 @@ namespace Controller.Core
         }
 
         public IEnumerable<Profile> Profiles => profiles.Values;
+        public IEnumerable<string> ProfileNames => profiles.Keys;
+        public bool HasProfile(string name) => profiles.ContainsKey(name);
+        public Profile? GetProfile(string name) => profiles.TryGetValue(name, out var p) ? p : null;
         public Profile CurrentProfile => current ?? throw new InvalidOperationException("No profile loaded");
 
         private void Load()
@@ -140,6 +143,8 @@ namespace Controller.Core
             ProfileChanged?.Invoke(this, new ProfileChangedEventArgs(p));
             return true;
         }
+
+        public void SaveCurrentProfile() => SaveProfile(CurrentProfile);
 
         public string ResolveProfile(string process, string windowTitle)
         {

--- a/Core/RawInputHandler.cs
+++ b/Core/RawInputHandler.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Core
+{
+    public enum MouseButtonType
+    {
+        Left,
+        Right,
+        Middle,
+        XButton1,
+        XButton2
+    }
+
+    /// <summary>
+    /// Provides global keyboard and mouse input using Windows Raw Input.
+    /// Call <see cref="ProcessMessage"/> from your window procedure whenever a WM_INPUT message is received.
+    /// </summary>
+    public static class RawInputHandler
+    {
+        internal const int WM_INPUT = 0x00FF;
+
+        private const uint RID_INPUT = 0x10000003;
+        private const int RIDEV_INPUTSINK = 0x100;
+        private const uint RIM_TYPEMOUSE = 0;
+        private const uint RIM_TYPEKEYBOARD = 1;
+        private const ushort HID_USAGE_PAGE_GENERIC = 0x01;
+        private const ushort HID_USAGE_GENERIC_MOUSE = 0x02;
+        private const ushort HID_USAGE_GENERIC_KEYBOARD = 0x06;
+
+        private const ushort RI_MOUSE_LEFT_BUTTON_DOWN = 0x0001;
+        private const ushort RI_MOUSE_LEFT_BUTTON_UP = 0x0002;
+        private const ushort RI_MOUSE_RIGHT_BUTTON_DOWN = 0x0004;
+        private const ushort RI_MOUSE_RIGHT_BUTTON_UP = 0x0008;
+        private const ushort RI_MOUSE_MIDDLE_BUTTON_DOWN = 0x0010;
+        private const ushort RI_MOUSE_MIDDLE_BUTTON_UP = 0x0020;
+        private const ushort RI_MOUSE_BUTTON_4_DOWN = 0x0040;
+        private const ushort RI_MOUSE_BUTTON_4_UP = 0x0080;
+        private const ushort RI_MOUSE_BUTTON_5_DOWN = 0x0100;
+        private const ushort RI_MOUSE_BUTTON_5_UP = 0x0200;
+        private const ushort RI_MOUSE_WHEEL = 0x0400;
+
+        private const int WM_KEYDOWN = 0x0100;
+        private const int WM_KEYUP = 0x0101;
+        private const int WM_SYSKEYDOWN = 0x0104;
+        private const int WM_SYSKEYUP = 0x0105;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RAWINPUTDEVICE
+        {
+            public ushort UsagePage;
+            public ushort Usage;
+            public int Flags;
+            public IntPtr Target;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RAWINPUTHEADER
+        {
+            public uint dwType;
+            public uint dwSize;
+            public IntPtr hDevice;
+            public IntPtr wParam;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RAWMOUSE
+        {
+            public ushort usFlags;
+            public uint ulButtons;
+            public ushort usButtonFlags;
+            public ushort usButtonData;
+            public uint ulRawButtons;
+            public int lLastX;
+            public int lLastY;
+            public uint ulExtraInformation;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RAWKEYBOARD
+        {
+            public ushort MakeCode;
+            public ushort Flags;
+            public ushort Reserved;
+            public ushort VKey;
+            public uint Message;
+            public uint ExtraInformation;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct RAWINPUT
+        {
+            [FieldOffset(0)] public RAWINPUTHEADER header;
+            [FieldOffset(16)] public RAWMOUSE mouse;
+            [FieldOffset(16)] public RAWKEYBOARD keyboard;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool RegisterRawInputDevices(RAWINPUTDEVICE[] pRawInputDevices, uint uiNumDevices, uint cbSize);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetRawInputData(IntPtr hRawInput, uint uiCommand, IntPtr pData, ref uint pcbSize, uint cbSizeHeader);
+
+        private static IntPtr _window = IntPtr.Zero;
+        private static bool _registered;
+
+        public static event Action<int, int>? KeyDown;
+        public static event Action<int, int>? KeyUp;
+        public static event Action<int, int>? MouseMove;
+        public static event Action<MouseButtonType, bool>? MouseButton;
+        public static event Action<int>? MouseWheel;
+
+        /// <summary>
+        /// Registers keyboard and mouse to receive WM_INPUT for the specified window handle.
+        /// </summary>
+        public static void RegisterDevices(IntPtr hwnd)
+        {
+            _window = hwnd;
+            RAWINPUTDEVICE[] rid = new RAWINPUTDEVICE[2];
+
+            rid[0].UsagePage = HID_USAGE_PAGE_GENERIC;
+            rid[0].Usage = HID_USAGE_GENERIC_MOUSE;
+            rid[0].Flags = RIDEV_INPUTSINK;
+            rid[0].Target = hwnd;
+
+            rid[1].UsagePage = HID_USAGE_PAGE_GENERIC;
+            rid[1].Usage = HID_USAGE_GENERIC_KEYBOARD;
+            rid[1].Flags = RIDEV_INPUTSINK;
+            rid[1].Target = hwnd;
+
+            if (!RegisterRawInputDevices(rid, (uint)rid.Length, (uint)Marshal.SizeOf<RAWINPUTDEVICE>()))
+            {
+                throw new InvalidOperationException("Failed to register raw input devices.");
+            }
+
+            _registered = true;
+        }
+
+        /// <summary>
+        /// Processes a WM_INPUT message from the application window procedure.
+        /// </summary>
+        public static void ProcessMessage(IntPtr lParam)
+        {
+            if (!_registered)
+                return;
+
+            uint dwSize = 0;
+            uint headerSize = (uint)Marshal.SizeOf<RAWINPUTHEADER>();
+
+            if (GetRawInputData(lParam, RID_INPUT, IntPtr.Zero, ref dwSize, headerSize) != 0 || dwSize == 0)
+                return;
+
+            IntPtr buffer = Marshal.AllocHGlobal((int)dwSize);
+            try
+            {
+                if (GetRawInputData(lParam, RID_INPUT, buffer, ref dwSize, headerSize) != dwSize)
+                    return;
+
+                RAWINPUT raw = Marshal.PtrToStructure<RAWINPUT>(buffer);
+                if (raw.header.dwType == RIM_TYPEKEYBOARD)
+                {
+                    HandleKeyboard(raw.keyboard);
+                }
+                else if (raw.header.dwType == RIM_TYPEMOUSE)
+                {
+                    HandleMouse(raw.mouse);
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        private static void HandleKeyboard(RAWKEYBOARD data)
+        {
+            bool isDown = data.Message == WM_KEYDOWN || data.Message == WM_SYSKEYDOWN;
+            bool isUp = data.Message == WM_KEYUP || data.Message == WM_SYSKEYUP;
+
+            if (!isDown && !isUp)
+                return;
+
+            if (isDown)
+                KeyDown?.Invoke(data.VKey, data.MakeCode);
+            else
+                KeyUp?.Invoke(data.VKey, data.MakeCode);
+        }
+
+        private static void HandleMouse(RAWMOUSE data)
+        {
+            if (data.lLastX != 0 || data.lLastY != 0)
+            {
+                MouseMove?.Invoke(data.lLastX, data.lLastY);
+            }
+
+            ushort flags = data.usButtonFlags;
+
+            if ((flags & RI_MOUSE_LEFT_BUTTON_DOWN) != 0)
+                MouseButton?.Invoke(MouseButtonType.Left, true);
+            if ((flags & RI_MOUSE_LEFT_BUTTON_UP) != 0)
+                MouseButton?.Invoke(MouseButtonType.Left, false);
+
+            if ((flags & RI_MOUSE_RIGHT_BUTTON_DOWN) != 0)
+                MouseButton?.Invoke(MouseButtonType.Right, true);
+            if ((flags & RI_MOUSE_RIGHT_BUTTON_UP) != 0)
+                MouseButton?.Invoke(MouseButtonType.Right, false);
+
+            if ((flags & RI_MOUSE_MIDDLE_BUTTON_DOWN) != 0)
+                MouseButton?.Invoke(MouseButtonType.Middle, true);
+            if ((flags & RI_MOUSE_MIDDLE_BUTTON_UP) != 0)
+                MouseButton?.Invoke(MouseButtonType.Middle, false);
+
+            if ((flags & RI_MOUSE_BUTTON_4_DOWN) != 0)
+                MouseButton?.Invoke(MouseButtonType.XButton1, true);
+            if ((flags & RI_MOUSE_BUTTON_4_UP) != 0)
+                MouseButton?.Invoke(MouseButtonType.XButton1, false);
+
+            if ((flags & RI_MOUSE_BUTTON_5_DOWN) != 0)
+                MouseButton?.Invoke(MouseButtonType.XButton2, true);
+            if ((flags & RI_MOUSE_BUTTON_5_UP) != 0)
+                MouseButton?.Invoke(MouseButtonType.XButton2, false);
+
+            if ((flags & RI_MOUSE_WHEEL) != 0)
+                MouseWheel?.Invoke((short)data.usButtonData);
+        }
+
+        /// <summary>
+        /// Clears registered window handle and stops raising events.
+        /// </summary>
+        public static void Dispose()
+        {
+            _registered = false;
+            _window = IntPtr.Zero;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Core project directory with profile data model and manager
- handle storing profiles and per-app switching via process or window title
- raise events on profile change or list change

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc66a69c8320b938cb477562d4d9