### PR TITLE
Add user settings form

### DIFF
--- a/InputToControllerMapper/MainForm.cs
+++ b/InputToControllerMapper/MainForm.cs
@@ -6,14 +6,19 @@ namespace InputToControllerMapper
 {
     public class MainForm : Form
     {
+        private readonly SettingsManager settingsManager;
+
         private ListBox profileList;
         private DataGridView mappingGrid;
         private GroupBox inputGroup;
         private GroupBox outputGroup;
         private TrayIcon tray;
+        private Button settingsButton;
 
-        public MainForm()
+        public MainForm(SettingsManager settings)
         {
+            settingsManager = settings;
+
             Text = "Input To Controller Mapper";
             Size = new Size(800, 600);
 
@@ -30,8 +35,20 @@ namespace InputToControllerMapper
             Controls.Add(outputGroup);
             Controls.Add(inputGroup);
 
+            settingsButton = new Button { Text = "Settings", Dock = DockStyle.Top, Height = 30 };
+            settingsButton.Click += (s, e) => {
+                using SettingsForm sf = new SettingsForm(settingsManager);
+                if (sf.ShowDialog() == DialogResult.OK)
+                {
+                    ApplyTheme();
+                }
+            };
+            Controls.Add(settingsButton);
+
             FormClosing += OnFormClosing;
             tray = new TrayIcon(this);
+
+            ApplyTheme();
         }
 
         private void OnFormClosing(object sender, FormClosingEventArgs e)
@@ -52,6 +69,20 @@ namespace InputToControllerMapper
         public void UpdateOutputState(string text)
         {
             outputGroup.Text = "Output State: " + text;
+        }
+
+        private void ApplyTheme()
+        {
+            if (settingsManager.Current.Theme == "Dark")
+            {
+                BackColor = Color.FromArgb(45, 45, 48);
+                ForeColor = Color.White;
+            }
+            else
+            {
+                BackColor = SystemColors.Control;
+                ForeColor = SystemColors.ControlText;
+            }
         }
     }
 }

--- a/InputToControllerMapper/Program.cs
+++ b/InputToControllerMapper/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Forms;
+using System.IO;
 
 namespace InputToControllerMapper
 {
@@ -12,7 +13,11 @@ namespace InputToControllerMapper
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            MainForm mainForm = new MainForm();
+            string appPath = Application.UserAppDataPath;
+            Directory.CreateDirectory(appPath);
+            var settingsManager = new SettingsManager(Path.Combine(appPath, "settings.json"));
+
+            MainForm mainForm = new MainForm(settingsManager);
             Application.Run(mainForm);
         }
     }

--- a/InputToControllerMapper/SettingsForm.cs
+++ b/InputToControllerMapper/SettingsForm.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace InputToControllerMapper
+{
+    public class SettingsForm : Form
+    {
+        private readonly SettingsManager settingsManager;
+        private readonly ProfileManager? profileManager;
+
+        private CheckBox startCheck;
+        private ComboBox profileCombo;
+        private ComboBox themeCombo;
+        private CheckBox diagnosticsCheck;
+        private CheckBox updateCheck;
+        private Button saveButton;
+
+        public SettingsForm(SettingsManager manager, ProfileManager? profiles = null)
+        {
+            settingsManager = manager;
+            profileManager = profiles;
+
+            Text = "Settings";
+            Size = new Size(400, 230);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+
+            startCheck = new CheckBox { Text = "Start with Windows", Location = new Point(10, 10), AutoSize = true };
+
+            profileCombo = new ComboBox { Location = new Point(10, 40), Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+            themeCombo = new ComboBox { Location = new Point(10, 70), Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+
+            diagnosticsCheck = new CheckBox { Text = "Enable diagnostics", Location = new Point(10, 100), AutoSize = true };
+            updateCheck = new CheckBox { Text = "Check for updates", Location = new Point(10, 130), AutoSize = true };
+
+            saveButton = new Button { Text = "Save", Location = new Point(10, 160), Width = 80 };
+            saveButton.Click += (s, e) => Save();
+
+            Controls.Add(startCheck);
+            Controls.Add(new Label { Text = "Default profile", Location = new Point(220, 43), AutoSize = true });
+            Controls.Add(profileCombo);
+            Controls.Add(new Label { Text = "Theme", Location = new Point(220, 73), AutoSize = true });
+            Controls.Add(themeCombo);
+            Controls.Add(diagnosticsCheck);
+            Controls.Add(updateCheck);
+            Controls.Add(saveButton);
+
+            themeCombo.Items.AddRange(new object[] { "Light", "Dark" });
+
+            if (profileManager != null)
+            {
+                foreach (var p in profileManager.All)
+                {
+                    profileCombo.Items.Add(p.Name);
+                }
+            }
+            if (profileCombo.Items.Count == 0)
+                profileCombo.Items.Add(settingsManager.Current.DefaultProfile);
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            startCheck.Checked = settingsManager.Current.StartWithWindows;
+            diagnosticsCheck.Checked = settingsManager.Current.EnableDiagnostics;
+            updateCheck.Checked = settingsManager.Current.CheckForUpdates;
+            themeCombo.SelectedItem = settingsManager.Current.Theme;
+            profileCombo.SelectedItem = settingsManager.Current.DefaultProfile;
+        }
+
+        private void Save()
+        {
+            settingsManager.Current.StartWithWindows = startCheck.Checked;
+            settingsManager.Current.DefaultProfile = profileCombo.SelectedItem?.ToString() ?? settingsManager.Current.DefaultProfile;
+            settingsManager.Current.Theme = themeCombo.SelectedItem?.ToString() ?? settingsManager.Current.Theme;
+            settingsManager.Current.EnableDiagnostics = diagnosticsCheck.Checked;
+            settingsManager.Current.CheckForUpdates = updateCheck.Checked;
+            settingsManager.Save();
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/InputToControllerMapper/SettingsManager.cs
+++ b/InputToControllerMapper/SettingsManager.cs
@@ -10,6 +10,12 @@ namespace InputToControllerMapper
     {
         public string ActiveProfile { get; set; } = "Default";
         public Dictionary<string, string> ProcessProfiles { get; set; } = new Dictionary<string, string>();
+
+        public bool StartWithWindows { get; set; } = false;
+        public string DefaultProfile { get; set; } = "Default";
+        public string Theme { get; set; } = "Light";
+        public bool EnableDiagnostics { get; set; } = false;
+        public bool CheckForUpdates { get; set; } = true;
     }
 
     public class SettingsManager


### PR DESCRIPTION
## Summary
- add new persistent app settings
- implement SettingsForm for editing preferences
- wire settings manager into Program and MainForm
- theme support with an ApplyTheme helper

## Testing
- `dotnet build InputToControllerMapper/InputToControllerMapper.csproj -nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc9a05ac83209cb206128189f7e6