### PR TITLE
Add unit test scaffolding

### DIFF
--- a/Tests/InputMapper.Tests/GlobalUsings.cs
+++ b/Tests/InputMapper.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tests/InputMapper.Tests/InputMapper.Tests.csproj
+++ b/Tests/InputMapper.Tests/InputMapper.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../InputToControllerMapper/InputToControllerMapper.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>

--- a/Tests/InputMapper.Tests/MacroEngineTests.cs
+++ b/Tests/InputMapper.Tests/MacroEngineTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InputToControllerMapper;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class TestSink : IButtonSink
+{
+    public readonly List<(string, bool)> States = new();
+    public void SetButtonState(string button, bool pressed) => States.Add((button, pressed));
+}
+
+public class MacroEngineTests
+{
+    [Fact]
+    public async Task MacroExecutesActions()
+    {
+        var sink = new TestSink();
+        var engine = new MacroEngine(sink);
+        var macro = new Macro
+        {
+            Name = "Test",
+            Actions = new List<MacroAction>
+            {
+                new PressAction("A"),
+                new DelayAction(10),
+                new ReleaseAction("A")
+            }
+        };
+        engine.AddMacro(macro);
+        var token = new CancellationTokenSource();
+        await Task.Run(() => engine.GetType().GetMethod("RunMacroAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(engine, new object[]{"Test", CancellationToken.None, 0}));
+        Assert.Equal(new[]{("A",true),("A",false)}, sink.States.ToArray());
+    }
+}

--- a/Tests/InputMapper.Tests/MappingEngineTests.cs
+++ b/Tests/InputMapper.Tests/MappingEngineTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Reflection;
+using InputToControllerMapper;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class DummyController : Nefarius.ViGEm.Client.Targets.Xbox360.IXbox360Controller
+{
+    public readonly Dictionary<string, object> States = new();
+    public void Connect() { }
+    public void Disconnect() { }
+    public void Dispose() { }
+    public void SubmitReport() { }
+    public void SetAxisValue(Nefarius.ViGEm.Client.Targets.Xbox360.Xbox360Axis axis, short value) => States[axis.ToString()] = value;
+    public void SetButtonState(Nefarius.ViGEm.Client.Targets.Xbox360.Xbox360Button button, bool pressed) => States[button.ToString()] = pressed;
+    public void SetSliderValue(Nefarius.ViGEm.Client.Targets.Xbox360.Xbox360Slider slider, byte value) => States[slider.ToString()] = value;
+}
+
+public class MappingEngineTests
+{
+    [Fact]
+    public void ApplyActionsSetsControllerState()
+    {
+        var engine = (MappingEngine)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(MappingEngine));
+        var controllerField = typeof(MappingEngine).GetField("controller", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var clientField = typeof(MappingEngine).GetField("client", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dummy = new DummyController();
+        controllerField.SetValue(engine, dummy);
+        clientField.SetValue(engine, null);
+        var profile = new MappingProfile();
+        profile.Mappings.Add(new InputMapping
+        {
+            Type = InputType.Key,
+            Code = "A",
+            Actions = new List<ControllerAction>{ new(){Element=ControllerElement.Button, Target="A"} }
+        });
+        engine.LoadProfile(profile);
+        engine.ProcessKeyEvent(System.Windows.Forms.Keys.A, true);
+        Assert.Equal(true, dummy.States["A"]);
+    }
+}

--- a/Tests/InputMapper.Tests/ProfileTests.cs
+++ b/Tests/InputMapper.Tests/ProfileTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using InputToControllerMapper;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class ProfileTests
+{
+    [Fact]
+    public void CanLoadAndSaveProfile()
+    {
+        var profile = new Profile
+        {
+            Name = "Test",
+            KeyBindings = new Dictionary<string, string> { ["A"] = "B" }
+        };
+        profile.Version = Profile.CurrentVersion;
+
+        string path = Path.Combine(Path.GetTempPath(), "prof.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(profile));
+        var loaded = Profile.FromJson(File.ReadAllText(path));
+        Assert.Equal("Test", loaded.Name);
+        Assert.Equal("B", loaded.KeyBindings["A"]);
+    }
+}

--- a/Tests/InputMapper.Tests/RawInputHandlerTests.cs
+++ b/Tests/InputMapper.Tests/RawInputHandlerTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Reflection;
+using System.Windows.Forms;
+using InputToControllerMapper;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class RawInputHandlerTests
+{
+    private static T CreateStruct<T>() where T : struct => (T)Activator.CreateInstance(typeof(T))!;
+
+    [Fact]
+    public void KeyboardEventsAreRaised()
+    {
+        var type = typeof(RawInputHandler);
+        var handler = (RawInputHandler)Activator.CreateInstance(type, true)!;
+        var handleKeyboard = type.GetMethod("HandleKeyboard", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var kbType = type.GetNestedType("RAWKEYBOARD", BindingFlags.NonPublic)!;
+        dynamic kb = Activator.CreateInstance(kbType)!;
+        kb.VKey = (ushort)Keys.A;
+        kb.MakeCode = 0;
+        kb.Flags = 0;
+
+        bool down = false, up = false;
+        handler.KeyDown += (_, e) => { down = e.IsKeyDown && e.VirtualKey == Keys.A; };
+        handler.KeyUp += (_, e) => { up = !e.IsKeyDown && e.VirtualKey == Keys.A; };
+
+        kb.Message = (uint)0x0100; // WM_KEYDOWN
+        handleKeyboard.Invoke(handler, new object[] { kb });
+        kb.Message = (uint)0x0101; // WM_KEYUP
+        handleKeyboard.Invoke(handler, new object[] { kb });
+
+        Assert.True(down);
+        Assert.True(up);
+    }
+
+    [Fact]
+    public void MouseEventsAreRaised()
+    {
+        var type = typeof(RawInputHandler);
+        var handler = (RawInputHandler)Activator.CreateInstance(type, true)!;
+        var handleMouse = type.GetMethod("HandleMouse", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var mouseType = type.GetNestedType("RAWMOUSE", BindingFlags.NonPublic)!;
+        dynamic m = Activator.CreateInstance(mouseType)!;
+
+        bool move = false, down = false, up = false, wheel = false;
+        handler.MouseMove += (_, _) => move = true;
+        handler.MouseButtonDown += (_, e) => { if (e.Button == RawMouseButton.Left) down = true; };
+        handler.MouseButtonUp += (_, e) => { if (e.Button == RawMouseButton.Left) up = true; };
+        handler.MouseWheel += (_, e) => { if (e.Delta == 120) wheel = true; };
+
+        m.lLastX = 1; m.lLastY = 2;
+        m.usButtonFlags = 0x0001; // left down
+        handleMouse.Invoke(handler, new object[] { m });
+        m.usButtonFlags = 0x0002; // left up
+        handleMouse.Invoke(handler, new object[] { m });
+        m.usButtonFlags = 0x0400; m.usButtonData = 120; // wheel
+        handleMouse.Invoke(handler, new object[] { m });
+
+        Assert.True(move);
+        Assert.True(down);
+        Assert.True(up);
+        Assert.True(wheel);
+    }
+}

--- a/Tests/InputMapper.Tests/WootingAnalogHandlerTests.cs
+++ b/Tests/InputMapper.Tests/WootingAnalogHandlerTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using InputToControllerMapper;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class WootingAnalogHandlerTests
+{
+    [Fact]
+    public void GetAnalogValueReturnsSdkValue()
+    {
+        using var handler = new WootingAnalogHandler();
+        Thread.Sleep(50); // allow poll thread
+        float val = handler.GetAnalogValue(10);
+        Assert.InRange(val, 0f, 1f);
+    }
+
+    [Fact]
+    public void KeyPressedAndReleasedEventsFire()
+    {
+        using var handler = new WootingAnalogHandler();
+        handler.PressThreshold = 0.2f;
+        handler.ReleaseThreshold = 0.1f;
+        ushort sc = 5;
+        bool pressed = false, released = false;
+        handler.KeyPressed += (s, e) => { if (e.ScanCode == sc) pressed = true; };
+        handler.KeyReleased += (s, e) => { if (e.ScanCode == sc) released = true; };
+        // wait for events to occur (values increment in stub)
+        for (int i = 0; i < 20 && !(pressed && released); i++)
+        {
+            Thread.Sleep(20);
+        }
+        Assert.True(pressed);
+        Assert.True(released);
+    }
+}

--- a/Tests/woot_stub/woot_stub.c
+++ b/Tests/woot_stub/woot_stub.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+static float values[256];
+int wooting_analog_initialise() { return 0; }
+int wooting_analog_uninitialize() { return 0; }
+int wooting_analog_set_key_mode(int mode) { return 0; }
+int wooting_analog_read(unsigned int device, unsigned short sc, float* value) {
+    values[sc] += 0.3f;
+    if(values[sc] > 1.0f) values[sc] = 0.0f;
+    *value = values[sc];
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create xUnit test project in `Tests`
- add tests for RawInputHandler, WootingAnalogHandler, MappingEngine, MacroEngine and Profile
- provide stub analog DLL for tests
- remove compiled stub binaries

## Testing
- `dotnet test Tests/InputMapper.Tests/InputMapper.Tests.csproj -v q` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6867dca8f4e48320822dc64ce7c5eeb2