### PR TITLE
Fix GetProfile return type

### DIFF
--- a/InputToControllerMapper/Core/ProfileManager.cs
+++ b/InputToControllerMapper/Core/ProfileManager.cs
@@ -73,7 +73,7 @@ namespace InputToControllerMapper
             return false;
         }
 
-        public Profile GetProfile(string name)
+        public Profile? GetProfile(string name)
         {
             profiles.TryGetValue(name, out var p);
             return p;


### PR DESCRIPTION
## Summary
- make `ProfileManager.GetProfile` return nullable `Profile?`

## Testing
- `dotnet test Tests/InputMapper.Tests/InputMapper.Tests.csproj` *(fails: Windows Desktop SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ebabca2483209502f0c98542dcef