### PR TITLE
Consolidate AnalogOptions type

### DIFF
--- a/InputToControllerMapper/Core/MappingEngine.cs
+++ b/InputToControllerMapper/Core/MappingEngine.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Nefarius.ViGEm.Client;
 using Nefarius.ViGEm.Client.Targets.Xbox360;
 using System.Windows.Forms;
+using Core;
 
 namespace InputToControllerMapper
 {

--- a/InputToControllerMapper/Core/MappingProfile.cs
+++ b/InputToControllerMapper/Core/MappingProfile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Core;
 
 namespace InputToControllerMapper
 {
@@ -35,13 +36,6 @@ namespace InputToControllerMapper
     {
         Linear,
         Squared
-    }
-
-    public class AnalogOptions
-    {
-        public float Deadzone { get; set; } = 0f;
-        public float Sensitivity { get; set; } = 1f;
-        public CurveType Curve { get; set; } = CurveType.Linear;
     }
 
     public class ControllerAction

--- a/InputToControllerMapper/InputToControllerMapper.csproj
+++ b/InputToControllerMapper/InputToControllerMapper.csproj
@@ -8,4 +8,7 @@
     <PackageReference Include="Nefarius.ViGEm.Client" Version="1.21.256" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- reference the shared Core library in the Windows app
- remove the duplicate `AnalogOptions` class from `MappingProfile`
- use the shared `Core.AnalogOptions` in app code

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ebaa81608320861f53a71de41615