### PR TITLE
Add JSON serialization tests

### DIFF
--- a/Tests/Serialization.Tests/GlobalUsings.cs
+++ b/Tests/Serialization.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tests/Serialization.Tests/MacroSerializationTests.cs
+++ b/Tests/Serialization.Tests/MacroSerializationTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using InputToControllerMapper;
+
+public class MacroSerializationTests
+{
+    [Fact]
+    public void MacroActionsSerializeAndDeserialize()
+    {
+        var engine = new MacroEngine(new DummySink());
+        var macro = new Macro
+        {
+            Name = "Test",
+            Repeat = 2,
+            Actions = new List<MacroAction>
+            {
+                new PressAction("A"),
+                new DelayAction(50),
+                new ReleaseAction("A")
+            }
+        };
+        engine.AddMacro(macro);
+
+        string json = engine.SerializeMacros();
+        Assert.Contains("\"type\": \"press\"", json);
+
+        var engine2 = new MacroEngine(new DummySink());
+        engine2.LoadMacros(json);
+        string json2 = engine2.SerializeMacros();
+        Assert.Equal(json, json2);
+
+        var list = JsonSerializer.Deserialize<List<Macro>>(json2)!;
+        Assert.IsType<PressAction>(list[0].Actions[0]);
+        Assert.IsType<DelayAction>(list[0].Actions[1]);
+        Assert.IsType<ReleaseAction>(list[0].Actions[2]);
+    }
+
+    private class DummySink : IButtonSink
+    {
+        public void SetButtonState(string button, bool pressed) { }
+    }
+}

--- a/Tests/Serialization.Tests/ProfileSerializationTests.cs
+++ b/Tests/Serialization.Tests/ProfileSerializationTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Core;
+
+public class ProfileSerializationTests
+{
+    [Fact]
+    public void ProfileRoundTripWithMappings()
+    {
+        var profile = new Profile
+        {
+            Name = "Test",
+            Mappings = new List<InputMapping>
+            {
+                new InputMapping
+                {
+                    Type = InputType.Key,
+                    Code = "A",
+                    Actions = new List<ControllerAction>
+                    {
+                        new ControllerAction { Element = ControllerElement.Button, Target = "X" },
+                        new ControllerAction { Element = ControllerElement.Axis, Target = "LX", AnalogOptions = new AnalogOptions { Deadzone = 0.1f, Sensitivity = 0.5f } }
+                    }
+                }
+            }
+        };
+
+        string json = JsonSerializer.Serialize(profile);
+        var loaded = JsonSerializer.Deserialize<Profile>(json);
+        Assert.NotNull(loaded);
+        Assert.Equal(profile.Name, loaded!.Name);
+        Assert.Equal(profile.Mappings.Count, loaded.Mappings.Count);
+        Assert.Equal(profile.Mappings[0].Actions[1].AnalogOptions!.Sensitivity,
+                     loaded.Mappings[0].Actions[1].AnalogOptions!.Sensitivity);
+    }
+}

--- a/Tests/Serialization.Tests/ProfileSettingsTests.cs
+++ b/Tests/Serialization.Tests/ProfileSettingsTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Core;
+
+public class ProfileSettingsTests
+{
+    [Fact]
+    public void ProfileSettingsRoundTrip()
+    {
+        var settings = new ProfileSettings
+        {
+            CurrentProfile = "Game",
+            AppProfiles = new List<AppProfileRule>
+            {
+                new AppProfileRule { ProcessName = "game.exe", ProfileName = "Game" },
+                new AppProfileRule { WindowTitleContains = "Editor", ProfileName = "Edit" }
+            }
+        };
+
+        string json = JsonSerializer.Serialize(settings);
+        var loaded = JsonSerializer.Deserialize<ProfileSettings>(json);
+        Assert.NotNull(loaded);
+        Assert.Equal(settings.CurrentProfile, loaded!.CurrentProfile);
+        Assert.Equal(2, loaded.AppProfiles.Count);
+        Assert.Equal("game.exe", loaded.AppProfiles[0].ProcessName);
+    }
+}

--- a/Tests/Serialization.Tests/Serialization.Tests.csproj
+++ b/Tests/Serialization.Tests/Serialization.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Core/Core.csproj" />
+    <Compile Include="../../InputToControllerMapper/Core/MacroEngine.cs" Link="MacroEngine.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add `Serialization.Tests` project
- test round-trip JSON for profiles and profile settings
- verify macro actions serialize using `JsonPolymorphic` discriminator

## Testing
- `dotnet test Tests/Serialization.Tests/Serialization.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6867f60db5048320a215d70fc6afee81