### PR TITLE
Improve Wooting stub handling

### DIFF
--- a/Tests/InputMapper.Tests/InputMapper.Tests.csproj
+++ b/Tests/InputMapper.Tests/InputMapper.Tests.csproj
@@ -7,11 +7,19 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../InputToControllerMapper/InputToControllerMapper.csproj" />
+    <ProjectReference Include="../../InputToControllerMapper/InputToControllerMapper.csproj" Condition="'$(OS)' == 'Windows_NT'" />
+    <ProjectReference Include="../../Core/Core.csproj" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="woot_stub/woot_stub.c" />
+  </ItemGroup>
+
+  <Target Name="BuildWootStub" BeforeTargets="Build" Condition="'$(OS)' != 'Windows_NT'">
+    <Exec Command="gcc -shared -fPIC &quot;$(MSBuildThisFileDirectory)woot_stub/woot_stub.c&quot; -o &quot;$(OutDir)wooting_analog_wrapper.dll&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- compile a fake `wooting_analog_wrapper.dll` when running tests on non‑Windows
- skip initialization if the real Wooting library can't be loaded

## Testing
- `dotnet test Tests/InputMapper.Tests/InputMapper.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f6131fd883209af3dc18e5f956d5