### PR TITLE
Fix CS0246 issues and enable nullable

### DIFF
--- a/Core/Profile.cs
+++ b/Core/Profile.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Core/ProfileManager.cs
+++ b/Core/ProfileManager.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Core/RawInputHandler.cs
+++ b/Core/RawInputHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.InteropServices;
 

--- a/Core/WootingAnalogHandler.cs
+++ b/Core/WootingAnalogHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading;
 using System.Runtime.InteropServices;

--- a/InputToControllerMapper/Core/RawInputHandler.cs
+++ b/InputToControllerMapper/Core/RawInputHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;

--- a/InputToControllerMapper/Core/RawMouseEventArgs.cs
+++ b/InputToControllerMapper/Core/RawMouseEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+namespace InputToControllerMapper
+{
+    public class RawMouseEventArgs : EventArgs
+    {
+        public int DeltaX { get; }
+        public int DeltaY { get; }
+
+        public RawMouseEventArgs(int deltaX, int deltaY)
+        {
+            DeltaX = deltaX;
+            DeltaY = deltaY;
+        }
+    }
+}

--- a/InputToControllerMapper/UI/InputCaptureForm.cs
+++ b/InputToControllerMapper/UI/InputCaptureForm.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Drawing;
 using System.Windows.Forms;


### PR DESCRIPTION
## Summary
- generate missing `RawMouseEventArgs` type
- enable nullable reference context in multiple core files
- include nullable context in Input to Controller code files

## Testing
- `dotnet build Core/Core.csproj -c Release`
- `dotnet build InputToControllerMapper/InputToControllerMapper.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f604fa308320acebc5353eadffe0