### PR TITLE
Add SettingsManager persistence test

### DIFF
--- a/Tests/InputMapper.Tests/SettingsManagerTests.cs
+++ b/Tests/InputMapper.Tests/SettingsManagerTests.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using InputToControllerMapper;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class SettingsManagerTests
+{
+    [Fact]
+    public void SavesAndLoadsSettings()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "settings_test.json");
+        if (File.Exists(path))
+            File.Delete(path);
+
+        var manager = new SettingsManager(path);
+        manager.Current.Theme = "Dark";
+        manager.Current.StartWithWindows = true;
+        manager.Current.CheckForUpdates = false;
+        manager.Current.EnableDiagnostics = true;
+        manager.Save();
+
+        var reloaded = new SettingsManager(path);
+        Assert.Equal("Dark", reloaded.Current.Theme);
+        Assert.True(reloaded.Current.StartWithWindows);
+        Assert.False(reloaded.Current.CheckForUpdates);
+        Assert.True(reloaded.Current.EnableDiagnostics);
+    }
+}


### PR DESCRIPTION
## Summary
- check that SettingsManager correctly persists settings

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f6c7ff7c8320aec85800c6c0f9da