### PR TITLE
Dispose tray icon and sync profile UI

### DIFF
--- a/InputToControllerMapper/UI/MainForm.cs
+++ b/InputToControllerMapper/UI/MainForm.cs
@@ -47,6 +47,8 @@ namespace InputToControllerMapper
 
             FormClosing += OnFormClosing;
             tray = new TrayIcon(this);
+            Application.ApplicationExit += (s, e) => tray.Dispose();
+            FormClosed += (s, e) => tray.Dispose();
 
             ApplyTheme();
         }

--- a/InputToControllerMapper/UI/MainWindow.cs
+++ b/InputToControllerMapper/UI/MainWindow.cs
@@ -47,6 +47,16 @@ namespace InputToControllerMapper.UI
 
             tray = new TrayIcon(this, profileManager);
 
+            Application.ApplicationExit += (s, e) => tray.Dispose();
+            FormClosed += (s, e) => tray.Dispose();
+            profileManager.ProfileChanged += (s, e) =>
+            {
+                if (InvokeRequired)
+                    BeginInvoke(new Action(RefreshProfileList));
+                else
+                    RefreshProfileList();
+            };
+
             RefreshProfileList();
         }
 
@@ -65,6 +75,7 @@ namespace InputToControllerMapper.UI
             foreach (var p in profileManager.All)
                 profileList.Items.Add(p.Name);
             profileList.SelectedItem = profileManager.ActiveProfile.Name;
+            LoadActiveProfile();
         }
 
         private void LoadSelectedProfile()
@@ -72,7 +83,16 @@ namespace InputToControllerMapper.UI
             if (profileList.SelectedItem is string name)
             {
                 profileManager.SetActiveProfile(name);
+                LoadActiveProfile();
             }
+        }
+
+        private void LoadActiveProfile()
+        {
+            var p = profileManager.ActiveProfile;
+            mappingGrid.Rows.Clear();
+            foreach (var kv in p.KeyBindings)
+                mappingGrid.Rows.Add(kv.Key, kv.Value);
         }
 
         protected override void OnShown(EventArgs e)

--- a/InputToControllerMapper/UI/Program.cs
+++ b/InputToControllerMapper/UI/Program.cs
@@ -15,9 +15,9 @@ namespace InputToControllerMapper
 
             string appPath = Application.UserAppDataPath;
             Directory.CreateDirectory(appPath);
-            var settingsManager = new SettingsManager(Path.Combine(appPath, "settings.json"));
+            var profileManager = new ProfileManager(Path.Combine(appPath, "profiles"));
 
-            MainForm mainForm = new MainForm(settingsManager);
+            using MainWindow mainForm = new MainWindow(profileManager);
             Application.Run(mainForm);
         }
     }

--- a/Tests/InputMapper.Tests/TrayIconTests.cs
+++ b/Tests/InputMapper.Tests/TrayIconTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+using InputToControllerMapper;
+using InputToControllerMapper.UI;
+using Xunit;
+
+namespace InputMapper.Tests;
+
+public class TrayIconTests
+{
+    [Fact]
+    public void ContextMenuShowMakesFormVisible()
+    {
+        using var form = new Form();
+        form.Hide();
+        var manager = new ProfileManager(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        using var tray = new TrayIcon(form, manager);
+
+        var notifyField = typeof(TrayIcon).GetField("notifyIcon", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var notify = (NotifyIcon)notifyField.GetValue(tray)!;
+        var showItem = notify.ContextMenuStrip!.Items
+            .OfType<ToolStripMenuItem>()
+            .First(i => i.Text == "Show");
+        showItem.PerformClick();
+
+        Assert.True(form.Visible);
+    }
+
+    [Fact]
+    public void ContextMenuEnabledTogglesState()
+    {
+        using var form = new Form();
+        var manager = new ProfileManager(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        using var tray = new TrayIcon(form, manager);
+
+        var notifyField = typeof(TrayIcon).GetField("notifyIcon", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var notify = (NotifyIcon)notifyField.GetValue(tray)!;
+        var enableItem = notify.ContextMenuStrip!.Items
+            .OfType<ToolStripMenuItem>()
+            .First(i => i.Text == "Enabled");
+        enableItem.PerformClick();
+
+        Assert.False(tray.Enabled);
+    }
+
+    [Fact]
+    public void ContextMenuProfileSwitchChangesActiveProfile()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(path);
+        var manager = new ProfileManager(path);
+        manager.CreateProfile("A");
+        manager.CreateProfile("B");
+        using var form = new MainWindow(manager);
+        using var tray = new TrayIcon(form, manager);
+
+        var notifyField = typeof(TrayIcon).GetField("notifyIcon", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var notify = (NotifyIcon)notifyField.GetValue(tray)!;
+        var profilesMenu = notify.ContextMenuStrip!.Items
+            .OfType<ToolStripMenuItem>()
+            .First(i => i.Text == "Profiles");
+        var itemB = profilesMenu.DropDownItems
+            .OfType<ToolStripMenuItem>()
+            .First(i => i.Text == "B");
+        itemB.PerformClick();
+
+        Assert.Equal("B", manager.ActiveProfile.Name);
+        var listField = typeof(MainWindow).GetField("profileList", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (ListBox)listField.GetValue(form)!;
+        Assert.Equal("B", list.SelectedItem);
+    }
+}


### PR DESCRIPTION
## Summary
- dispose `TrayIcon` when the app closes
- keep main window's profile list in sync
- load profile mappings when switching profiles
- cover tray icon context menu behaviors with unit tests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f639c38083208e0d1068d093787d