### PR TITLE
Implement unified profile management

### DIFF
--- a/Core/MouseToStickMapper.cs
+++ b/Core/MouseToStickMapper.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace Core
+{
+    public enum StickCurveShape
+    {
+        Linear,
+        Exponential,
+        DualZone
+    }
+
+    /// <summary>
+    /// Translates raw mouse movement into normalized stick values.
+    /// </summary>
+    public class MouseToStickMapper
+    {
+        public float SensitivityX { get; set; } = 1f;
+        public float SensitivityY { get; set; } = 1f;
+        public float Deadzone { get; set; } = 0f;
+        public float Acceleration { get; set; } = 0f;
+        public float Smoothing { get; set; } = 0f;
+        public bool InvertY { get; set; }
+        public StickCurveShape Curve { get; set; } = StickCurveShape.Linear;
+        public float Exponent { get; set; } = 1.5f;          // for Exponential and DualZone curves
+        public float OuterExponent { get; set; } = 1.0f;      // for DualZone
+        public float DualZoneThreshold { get; set; } = 0.5f;  // 0..1
+
+        private float smoothX;
+        private float smoothY;
+
+        /// <summary>
+        /// Process mouse delta and return stick axis values in range -32767..32767.
+        /// </summary>
+        public (short X, short Y) Map(int deltaX, int deltaY)
+        {
+            float x = ProcessAxis(deltaX, SensitivityX, ref smoothX);
+            float y = ProcessAxis(deltaY, SensitivityY, ref smoothY);
+
+            if (InvertY)
+                y = -y;
+
+            short sx = (short)Math.Clamp(x * 32767f, -32767f, 32767f);
+            short sy = (short)Math.Clamp(y * 32767f, -32767f, 32767f);
+            return (sx, sy);
+        }
+
+        private float ProcessAxis(int delta, float sensitivity, ref float smooth)
+        {
+            float value = delta * sensitivity;
+
+            if (Acceleration > 0f)
+                value *= 1f + MathF.Abs(value) * Acceleration;
+
+            if (Smoothing > 0f)
+            {
+                smooth += (value - smooth) * Smoothing;
+                value = smooth;
+            }
+
+            float sign = MathF.Sign(value);
+            float magnitude = MathF.Abs(value);
+
+            if (magnitude < Deadzone)
+                return 0f;
+
+            magnitude = (magnitude - Deadzone) / (1f - Deadzone);
+            magnitude = ApplyCurve(magnitude);
+
+            return sign * magnitude;
+        }
+
+        private float ApplyCurve(float value)
+        {
+            value = MathF.Min(MathF.Max(value, 0f), 1f);
+
+            switch (Curve)
+            {
+                case StickCurveShape.Linear:
+                    return value;
+                case StickCurveShape.Exponential:
+                    return MathF.Pow(value, Exponent);
+                case StickCurveShape.DualZone:
+                    if (value < DualZoneThreshold)
+                    {
+                        float inner = value / DualZoneThreshold;
+                        return MathF.Pow(inner, Exponent) * DualZoneThreshold;
+                    }
+                    else
+                    {
+                        float outer = (value - DualZoneThreshold) / (1f - DualZoneThreshold);
+                        return MathF.Pow(outer, OuterExponent) * (1f - DualZoneThreshold) + DualZoneThreshold;
+                    }
+                default:
+                    return value;
+            }
+        }
+    }
+}

--- a/Core/Profile.cs
+++ b/Core/Profile.cs
@@ -59,6 +59,9 @@ namespace Core
         public List<ControllerAction> Actions { get; set; } = new();
     }
 
+    /// <summary>
+    /// Collection of input mappings stored on disk and applied at runtime.
+    /// </summary>
     public class Profile
     {
         public string Name { get; set; } = "Default";

--- a/Core/ProfileManager.cs
+++ b/Core/ProfileManager.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Core
+{
+    /// <summary>
+    /// Manages loading and saving of <see cref="Profile"/> instances and keeps
+    /// track of the currently active profile.
+    /// </summary>
+    public class ProfileManager
+    {
+        private readonly string profilesPath;
+        private readonly Dictionary<string, Profile> profiles = new();
+
+        /// <summary>Raised when <see cref="CurrentProfile"/> changes.</summary>
+        public event EventHandler? ProfileChanged;
+
+        /// <summary>
+        /// Create a manager that stores profiles under the given application
+        /// subfolder inside the user's roaming AppData.
+        /// </summary>
+        public ProfileManager(string appName)
+        {
+            profilesPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                appName);
+            Directory.CreateDirectory(profilesPath);
+            LoadProfiles();
+        }
+
+        /// <summary>All known profiles.</summary>
+        public IEnumerable<Profile> Profiles => profiles.Values;
+
+        /// <summary>The currently active profile.</summary>
+        public Profile CurrentProfile { get; private set; } = new();
+
+        private void LoadProfiles()
+        {
+            profiles.Clear();
+            foreach (var file in Directory.GetFiles(profilesPath, "*.json"))
+            {
+                try
+                {
+                    var profile = Profile.Load(file);
+                    profile.Name = Path.GetFileNameWithoutExtension(file);
+                    profiles[profile.Name] = profile;
+                }
+                catch
+                {
+                    // ignore malformed profile
+                }
+            }
+
+            if (!profiles.TryGetValue("Default", out var current))
+            {
+                current = new Profile { Name = "Default" };
+                SaveProfile(current);
+                profiles[current.Name] = current;
+            }
+
+            CurrentProfile = current;
+        }
+
+        /// <summary>Persist a profile to disk.</summary>
+        public void SaveProfile(Profile profile)
+        {
+            string path = Path.Combine(profilesPath, profile.Name + ".json");
+            profile.Save(path);
+        }
+
+        /// <summary>Switch to the profile with the given name.</summary>
+        public bool SetCurrentProfile(string name)
+        {
+            if (profiles.TryGetValue(name, out var p))
+            {
+                CurrentProfile = p;
+                ProfileChanged?.Invoke(this, EventArgs.Empty);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>Return the profile with the specified name if it exists.</summary>
+        public Profile? GetProfile(string name) =>
+            profiles.TryGetValue(name, out var p) ? p : null;
+
+        /// <summary>Add a new profile to the manager.</summary>
+        public bool AddProfile(Profile profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile.Name) || profiles.ContainsKey(profile.Name))
+                return false;
+            profiles[profile.Name] = profile;
+            SaveProfile(profile);
+            return true;
+        }
+
+        /// <summary>Delete a profile by name.</summary>
+        public bool DeleteProfile(string name)
+        {
+            if (!profiles.Remove(name))
+                return false;
+            string path = Path.Combine(profilesPath, name + ".json");
+            if (File.Exists(path))
+                File.Delete(path);
+            if (CurrentProfile.Name == name)
+            {
+                CurrentProfile = profiles.Values.FirstOrDefault() ?? new Profile { Name = "Default" };
+                ProfileChanged?.Invoke(this, EventArgs.Empty);
+            }
+            return true;
+        }
+
+        /// <summary>Create a duplicate of an existing profile.</summary>
+        public bool CloneProfile(string source, string dest)
+        {
+            if (!profiles.TryGetValue(source, out var p) || profiles.ContainsKey(dest))
+                return false;
+            var clone = new Profile
+            {
+                Name = dest,
+                Mappings = p.Mappings
+                    .Select(m => new InputMapping
+                    {
+                        Type = m.Type,
+                        Code = m.Code,
+                        Actions = m.Actions
+                            .Select(a => new ControllerAction
+                            {
+                                Element = a.Element,
+                                Target = a.Target,
+                                AnalogOptions = a.AnalogOptions == null ? null : new AnalogOptions
+                                {
+                                    Deadzone = a.AnalogOptions.Deadzone,
+                                    Sensitivity = a.AnalogOptions.Sensitivity,
+                                    Curve = a.AnalogOptions.Curve
+                                }
+                            }).ToList()
+                    }).ToList()
+            };
+            profiles[dest] = clone;
+            SaveProfile(clone);
+            return true;
+        }
+
+        /// <summary>Check if a profile with the given name exists.</summary>
+        public bool HasProfile(string name) => profiles.ContainsKey(name);
+    }
+}

--- a/InputToControllerMapper/Core/ConfigManager.cs
+++ b/InputToControllerMapper/Core/ConfigManager.cs
@@ -2,6 +2,9 @@ using System.Text.Json;
 
 namespace InputToControllerMapper.Core
 {
+    /// <summary>
+    /// Helper utilities for loading and saving JSON configuration files.
+    /// </summary>
     public static class ConfigManager
     {
         public static T? Load<T>(string path)

--- a/InputToControllerMapper/Core/SettingsManager.cs
+++ b/InputToControllerMapper/Core/SettingsManager.cs
@@ -6,9 +6,10 @@ using System.Text.Json;
 
 namespace InputToControllerMapper
 {
+    /// <summary>Serializable application configuration.</summary>
     public class Settings
     {
-        public string ActiveProfile { get; set; } = "Default";
+        public string CurrentProfile { get; set; } = "Default";
         public Dictionary<string, string> ProcessProfiles { get; set; } = new Dictionary<string, string>();
 
         // Advanced/general app options
@@ -19,6 +20,9 @@ namespace InputToControllerMapper
         public bool CheckForUpdates { get; set; } = true;
     }
 
+    /// <summary>
+    /// Helper for reading and persisting <see cref="Settings"/> to disk.
+    /// </summary>
     public class SettingsManager
     {
         private readonly string filePath;
@@ -57,7 +61,7 @@ namespace InputToControllerMapper
 
         public string GetProfileForProcess(string processName)
         {
-            return settings.ProcessProfiles.TryGetValue(processName, out var profile) ? profile : settings.ActiveProfile;
+            return settings.ProcessProfiles.TryGetValue(processName, out var profile) ? profile : settings.CurrentProfile;
         }
 
         public void SetProfileForProcess(string processName, string profile)
@@ -66,9 +70,9 @@ namespace InputToControllerMapper
             Save();
         }
 
-        public void SetActiveProfile(string name)
+        public void SetCurrentProfile(string name)
         {
-            settings.ActiveProfile = name;
+            settings.CurrentProfile = name;
             Save();
         }
 
@@ -82,7 +86,7 @@ namespace InputToControllerMapper
             }
             catch
             {
-                return settings.ActiveProfile;
+                return settings.CurrentProfile;
             }
         }
     }

--- a/InputToControllerMapper/SettingsForm.cs
+++ b/InputToControllerMapper/SettingsForm.cs
@@ -5,8 +5,9 @@ using Core;
 
 namespace InputToControllerMapper
 {
-    // UI dialog for modifying persistent user preferences.
-    // Merged after resolving conflicts with main (@iqrez)
+    /// <summary>
+    /// UI dialog for modifying persistent user preferences.
+    /// </summary>
     public class SettingsForm : Form
     {
         private readonly SettingsManager settingsManager;

--- a/InputToControllerMapper/UI/InputCaptureForm.cs
+++ b/InputToControllerMapper/UI/InputCaptureForm.cs
@@ -6,6 +6,9 @@ using Nefarius.ViGEm.Client.Targets.Xbox360;
 
 namespace InputToControllerMapper
 {
+    /// <summary>
+    /// Diagnostic window for capturing raw input and displaying controller state.
+    /// </summary>
     public class InputCaptureForm : Form
     {
         private RawInputHandler rawInput;

--- a/InputToControllerMapper/UI/MacroEditor.cs
+++ b/InputToControllerMapper/UI/MacroEditor.cs
@@ -4,6 +4,9 @@ using System.Windows.Forms;
 
 namespace InputToControllerMapper.UI
 {
+    /// <summary>
+    /// Minimal window used to edit serialized macro actions.
+    /// </summary>
     public class MacroEditor : Form
     {
         private readonly TextBox text;

--- a/InputToControllerMapper/UI/MainForm.cs
+++ b/InputToControllerMapper/UI/MainForm.cs
@@ -5,6 +5,9 @@ using Core;
 
 namespace InputToControllerMapper
 {
+    /// <summary>
+    /// Simplified main form used in unit tests to host the tray icon.
+    /// </summary>
     public class MainForm : Form
     {
         private readonly SettingsManager settingsManager;
@@ -22,6 +25,7 @@ namespace InputToControllerMapper
         {
             settingsManager = settings ?? throw new ArgumentNullException(nameof(settings));
             profileManager = profiles ?? throw new ArgumentNullException(nameof(profiles));
+            settingsManager.Load();
 
             // Window setup
             Text = "Input To Controller Mapper";
@@ -87,8 +91,16 @@ namespace InputToControllerMapper
             tray = new TrayIcon(this, profileManager);
 
             // Cleanup tray on close/app exit
-            Application.ApplicationExit += (s, e) => tray.Dispose();
-            FormClosed += (s, e) => tray.Dispose();
+            Application.ApplicationExit += (s, e) =>
+            {
+                tray.Dispose();
+                settingsManager.Save();
+            };
+            FormClosed += (s, e) =>
+            {
+                tray.Dispose();
+                settingsManager.Save();
+            };
 
             // Hide to tray on user close
             FormClosing += OnFormClosing;

--- a/InputToControllerMapper/UI/MainWindow.cs
+++ b/InputToControllerMapper/UI/MainWindow.cs
@@ -6,6 +6,9 @@ using Core;
 
 namespace InputToControllerMapper.UI
 {
+    /// <summary>
+    /// Main application window that displays the current profile and mappings.
+    /// </summary>
     public class MainWindow : Form
     {
         private readonly ProfileManager profileManager;
@@ -79,23 +82,23 @@ namespace InputToControllerMapper.UI
             foreach (var p in profileManager.Profiles)
                 profileList.Items.Add(p.Name);
 
-            if (profileManager.ActiveProfile != null)
-                profileList.SelectedItem = profileManager.ActiveProfile.Name;
-            LoadActiveProfile();
+            if (profileManager.CurrentProfile != null)
+                profileList.SelectedItem = profileManager.CurrentProfile.Name;
+            LoadCurrentProfile();
         }
 
         private void LoadSelectedProfile()
         {
             if (profileList.SelectedItem is string name)
             {
-                profileManager.SetActiveProfile(name);
-                LoadActiveProfile();
+                profileManager.SetCurrentProfile(name);
+                LoadCurrentProfile();
             }
         }
 
-        private void LoadActiveProfile()
+        private void LoadCurrentProfile()
         {
-            var p = profileManager.ActiveProfile;
+            var p = profileManager.CurrentProfile;
             mappingGrid.Rows.Clear();
             if (p != null)
             {

--- a/InputToControllerMapper/UI/ProfileEditor.cs
+++ b/InputToControllerMapper/UI/ProfileEditor.cs
@@ -6,6 +6,9 @@ using Core;
 
 namespace InputToControllerMapper.UI
 {
+    /// <summary>
+    /// Simple UI for creating, cloning and deleting profiles.
+    /// </summary>
     public class ProfileEditor : Form
     {
         private readonly ProfileManager manager;

--- a/InputToControllerMapper/UI/TrayIcon.cs
+++ b/InputToControllerMapper/UI/TrayIcon.cs
@@ -5,12 +5,16 @@ using Core;
 
 namespace InputToControllerMapper
 {
+    /// <summary>
+    /// System tray integration for the application.
+    /// </summary>
     public class TrayIcon : IDisposable
     {
         private readonly NotifyIcon notifyIcon;
         private readonly Form mainForm;
         private readonly ProfileManager manager;
         private bool enabled = true;
+        private bool disposed;
 
         public bool Enabled => enabled;
 
@@ -73,6 +77,9 @@ namespace InputToControllerMapper
 
         public void Dispose()
         {
+            if (disposed)
+                return;
+            disposed = true;
             notifyIcon.Dispose();
         }
     }

--- a/Tests/InputMapper.Tests/ProfileManagerTests.cs
+++ b/Tests/InputMapper.Tests/ProfileManagerTests.cs
@@ -43,4 +43,19 @@ public class ProfileManagerTests
         if (Directory.Exists(dir))
             Directory.Delete(dir, true);
     }
+
+    [Fact]
+    public void SwitchingProfileRaisesEvent()
+    {
+        string app = "Evt" + Guid.NewGuid().ToString("N");
+        var mgr = new ProfileManager(app);
+        mgr.AddProfile(new Profile { Name = "Game" });
+        bool raised = false;
+        mgr.ProfileChanged += (_, __) => raised = true;
+        mgr.SetCurrentProfile("Game");
+        Assert.True(raised);
+        string dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), app);
+        if (Directory.Exists(dir))
+            Directory.Delete(dir, true);
+    }
 }

--- a/Tests/InputMapper.Tests/TrayIconTests.cs
+++ b/Tests/InputMapper.Tests/TrayIconTests.cs
@@ -47,7 +47,7 @@ public class TrayIconTests
     }
 
     [Fact]
-    public void ContextMenuProfileSwitchChangesActiveProfile()
+    public void ContextMenuProfileSwitchChangesProfile()
     {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(path);
@@ -67,7 +67,7 @@ public class TrayIconTests
             .First(i => i.Text == "B");
         itemB.PerformClick();
 
-        Assert.Equal("B", manager.ActiveProfile.Name);
+        Assert.Equal("B", manager.CurrentProfile.Name);
         var listField = typeof(MainWindow).GetField("profileList", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var list = (ListBox)listField.GetValue(form)!;
         Assert.Equal("B", list.SelectedItem);


### PR DESCRIPTION
## Summary
- add `ProfileManager` in core library
- introduce `MouseToStickMapper` inside core project
- unify profile APIs to `CurrentProfile`/`SetCurrentProfile`
- connect settings manager saving and loading in forms
- guard tray icon disposal
- document public classes
- update unit tests for new API

## Testing
- `dotnet test Tests/InputMapper.Tests/InputMapper.Tests.csproj` *(fails: type or namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680ddd8ce4832089d7c6284bead5da