### PR TITLE
Configure project references

### DIFF
--- a/HeadlessControllerEmulator/HeadlessControllerEmulator.csproj
+++ b/HeadlessControllerEmulator/HeadlessControllerEmulator.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <RootNamespace>HeadlessControllerEmulator</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nefarius.ViGEm.Client" Version="1.21.256" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+    <Compile Include="..\InputToControllerMapper\Core\*.cs" Link="Core\%(FileName)%(Extension)" />
+    <Compile Include="..\InputToControllerMapper\MouseToStickConfig.cs" Link="MouseToStickConfig.cs" />
+    <Compile Include="..\InputToControllerMapper\VirtualControllerManager.cs" Link="VirtualControllerManager.cs" />
+  </ItemGroup>
+</Project>

--- a/HeadlessControllerEmulator/Program.cs
+++ b/HeadlessControllerEmulator/Program.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Windows.Forms;
+using Core;
+using InputToControllerMapper;
+
+namespace HeadlessControllerEmulator
+{
+    internal class HiddenForm : Form
+    {
+        private readonly MappingEngine engine;
+        private readonly ProfileManager manager;
+
+        public HiddenForm()
+        {
+            manager = new ProfileManager("HeadlessEmulator");
+            engine = new MappingEngine();
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            var input = RawInputHandler.Instance;
+            input.RegisterDevices(Handle);
+            input.KeyDown += (s, args) => engine.ProcessKeyEvent(args.VirtualKey, true);
+            input.KeyUp += (s, args) => engine.ProcessKeyEvent(args.VirtualKey, false);
+            input.MouseButtonDown += (s, args) => engine.ProcessMouseButtonEvent((MouseButton)args.Button, true);
+            input.MouseButtonUp += (s, args) => engine.ProcessMouseButtonEvent((MouseButton)args.Button, false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                engine.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    internal static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            ApplicationConfiguration.Initialize();
+            Application.Run(new HiddenForm());
+        }
+    }
+}

--- a/InputToControllerMapper.sln
+++ b/InputToControllerMapper.sln
@@ -6,6 +6,8 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", "{10352160-6EF9-4DB2-9E20-24FD8E824AFE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputToControllerMapper", "InputToControllerMapper\InputToControllerMapper.csproj", "{FD25733C-EA84-4040-82DC-144B850564F6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeadlessControllerEmulator", "HeadlessControllerEmulator\HeadlessControllerEmulator.csproj", "{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}"
+EndProject
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{99DA5C86-234A-427A-8066-6484A743EB69}"
 EndProject
@@ -30,6 +32,10 @@ Global
                 {FD25733C-EA84-4040-82DC-144B850564F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {FD25733C-EA84-4040-82DC-144B850564F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {FD25733C-EA84-4040-82DC-144B850564F6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Release|Any CPU.Build.0 = Release|Any CPU
                 {9ACB542D-17E8-436E-92CF-CEC246151C09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9ACB542D-17E8-436E-92CF-CEC246151C09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9ACB542D-17E8-436E-92CF-CEC246151C09}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Launch the application from the `InputToControllerMapper` project:
 dotnet run --project InputToControllerMapper
 ```
 
+### Headless controller emulator
+
+For a minimal, non-UI version run:
+
+```bash
+dotnet run --project HeadlessControllerEmulator
+```
+
 ## Tests
 
 Unit tests live under the `Tests` folder and can be run with:

--- a/Tests/InputMapper.Tests/InputMapper.Tests.csproj
+++ b/Tests/InputMapper.Tests/InputMapper.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Nefarius.ViGEm.Client" Version="1.21.256" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <Target Name="BuildNativeStubs" BeforeTargets="Build">


### PR DESCRIPTION
## Summary
- update System.Text.Json to v8.0.5 in InputMapper.Tests
- add new HeadlessControllerEmulator project without UI
- reference new project in solution and README

## Testing
- `dotnet restore InputToControllerMapper.sln` *(fails: command not found)*
- `dotnet build InputToControllerMapper.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682697792483209be5798de56e661d