### PR TITLE
Fix Wooting analog handler event usage

### DIFF
--- a/InputToControllerMapper/Core/WootingAnalogHandler.cs
+++ b/InputToControllerMapper/Core/WootingAnalogHandler.cs
@@ -46,11 +46,11 @@ namespace InputToControllerMapper
         public float ReleaseThreshold { get; set; } = 0.2f;
 
         /// <summary>Raised when a key's analog value exceeds <see cref="PressThreshold"/>.</summary>
-        public event EventHandler<AnalogKeyEventArgs> KeyPressed;
+        public event EventHandler<AnalogKeyEventArgs>? KeyPressed;
         /// <summary>Raised when a key's analog value goes below <see cref="ReleaseThreshold"/>.</summary>
-        public event EventHandler<AnalogKeyEventArgs> KeyReleased;
+        public event EventHandler<AnalogKeyEventArgs>? KeyReleased;
         /// <summary>Raised every poll with the current value of a key.</summary>
-        public event EventHandler<AnalogKeyEventArgs> AnalogValueUpdated;
+        public event EventHandler<AnalogKeyEventArgs>? AnalogValueUpdated;
 
         /// <summary>
         /// Initialises the SDK and starts polling in the background.

--- a/InputToControllerMapper/UI/InputCaptureForm.cs
+++ b/InputToControllerMapper/UI/InputCaptureForm.cs
@@ -72,16 +72,10 @@ namespace InputToControllerMapper
 
             try
             {
-                // Support both delegate (constructor) and event handler usage
-                wootingHandler = new WootingAnalogHandler(v =>
+                wootingHandler = new WootingAnalogHandler();
+                wootingHandler.AnalogValueUpdated += (_, e) =>
                 {
-                    byte val = (byte)(Math.Clamp(v, 0f, 1f) * 255);
-                    controller.SetSliderValue(Xbox360Slider.LeftTrigger, val);
-                    controller.SubmitReport();
-                });
-                wootingHandler.AnalogValueChanged += (_, value) =>
-                {
-                    byte val = (byte)(Math.Clamp(value, 0f, 1f) * 255);
+                    byte val = (byte)(Math.Clamp(e.Value, 0f, 1f) * 255);
                     controller.SetSliderValue(Xbox360Slider.LeftTrigger, val);
                     controller.SubmitReport();
                 };


### PR DESCRIPTION
## Summary
- fix event handler in `InputCaptureForm` to use `AnalogValueUpdated`
- mark events in `WootingAnalogHandler` as nullable

## Testing
- `dotnet test Tests/InputMapper.Tests/InputMapper.Tests.csproj --verbosity normal`
- `dotnet test Tests/Serialization.Tests/Serialization.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68687ddb7c808320834918d36726c24e