### PR TITLE
Fix controller mapping dictionaries

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nefarius.ViGEm.Client" Version="1.21.256" />

--- a/Core/IVirtualController.cs
+++ b/Core/IVirtualController.cs
@@ -4,8 +4,15 @@ using Nefarius.ViGEm.Client.Targets.DualShock4;
 
 namespace Core
 {
+    public enum VirtualControllerType
+    {
+        Xbox360,
+        DualShock4
+    }
+
     public interface IVirtualController
     {
+        VirtualControllerType ControllerType { get; }
         void SetButton(Xbox360Button button, bool pressed);
         void SetButton(DualShock4Button button, bool pressed);
         void SetAxis(Xbox360Axis axis, short value);

--- a/Core/MappingEngine.cs
+++ b/Core/MappingEngine.cs
@@ -19,6 +19,71 @@ namespace Core
         private readonly Dictionary<string, float> triggerStates = new();
         private readonly Dictionary<string, bool> dpadStates = new();
 
+        private static readonly Dictionary<string, Xbox360Button> XboxButtons = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Up"] = Xbox360Button.Up,
+            ["Down"] = Xbox360Button.Down,
+            ["Left"] = Xbox360Button.Left,
+            ["Right"] = Xbox360Button.Right,
+            ["Start"] = Xbox360Button.Start,
+            ["Back"] = Xbox360Button.Back,
+            ["LeftThumb"] = Xbox360Button.LeftThumb,
+            ["RightThumb"] = Xbox360Button.RightThumb,
+            ["LeftShoulder"] = Xbox360Button.LeftShoulder,
+            ["RightShoulder"] = Xbox360Button.RightShoulder,
+            ["Guide"] = Xbox360Button.Guide,
+            ["A"] = Xbox360Button.A,
+            ["B"] = Xbox360Button.B,
+            ["X"] = Xbox360Button.X,
+            ["Y"] = Xbox360Button.Y
+        };
+
+        private static readonly Dictionary<string, DualShock4Button> Ds4Buttons = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Cross"] = DualShock4Button.Cross,
+            ["Circle"] = DualShock4Button.Circle,
+            ["Square"] = DualShock4Button.Square,
+            ["Triangle"] = DualShock4Button.Triangle,
+            ["L1"] = DualShock4Button.ShoulderLeft,
+            ["R1"] = DualShock4Button.ShoulderRight,
+            ["L2"] = DualShock4Button.TriggerLeft,
+            ["R2"] = DualShock4Button.TriggerRight,
+            ["Share"] = DualShock4Button.Share,
+            ["Options"] = DualShock4Button.Options,
+            ["L3"] = DualShock4Button.ThumbLeft,
+            ["R3"] = DualShock4Button.ThumbRight,
+            ["PS"] = DualShock4Button.Ps,
+            ["Touchpad"] = DualShock4Button.Touchpad
+        };
+
+        private static readonly Dictionary<string, Xbox360Axis> XboxAxes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LeftThumbX"] = Xbox360Axis.LeftThumbX,
+            ["LeftThumbY"] = Xbox360Axis.LeftThumbY,
+            ["RightThumbX"] = Xbox360Axis.RightThumbX,
+            ["RightThumbY"] = Xbox360Axis.RightThumbY
+        };
+
+        private static readonly Dictionary<string, DualShock4Axis> Ds4Axes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LeftStickX"] = DualShock4Axis.LeftThumbX,
+            ["LeftStickY"] = DualShock4Axis.LeftThumbY,
+            ["RightStickX"] = DualShock4Axis.RightThumbX,
+            ["RightStickY"] = DualShock4Axis.RightThumbY
+        };
+
+        private static readonly Dictionary<string, Xbox360Slider> XboxTriggers = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LeftTrigger"] = Xbox360Slider.LeftTrigger,
+            ["RightTrigger"] = Xbox360Slider.RightTrigger
+        };
+
+        private static readonly Dictionary<string, DualShock4Slider> Ds4Triggers = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["L2"] = DualShock4Slider.LeftTrigger,
+            ["R2"] = DualShock4Slider.RightTrigger
+        };
+
         private int mouseDeltaX;
         private int mouseDeltaY;
 
@@ -109,33 +174,41 @@ namespace Core
         {
             ApplyMouseMappings();
 
-            foreach (var kv in buttonStates)
+            if (ctrl.ControllerType == VirtualControllerType.Xbox360)
             {
-                if (Enum.TryParse<Xbox360Button>(kv.Key, out var xbButton))
-                    ctrl.SetButton(xbButton, kv.Value);
-                else if (Enum.TryParse<DualShock4Button>(kv.Key, out var dsButton))
-                    ctrl.SetButton(dsButton, kv.Value);
+                foreach (var kv in buttonStates)
+                    if (XboxButtons.TryGetValue(kv.Key, out var btn))
+                        ctrl.SetButton(btn, kv.Value);
+
+                foreach (var kv in axisStates)
+                    if (XboxAxes.TryGetValue(kv.Key, out var axis))
+                        ctrl.SetAxis(axis, (short)(kv.Value * short.MaxValue));
+
+                foreach (var kv in triggerStates)
+                    if (XboxTriggers.TryGetValue(kv.Key, out var trig))
+                        ctrl.SetTrigger(trig, (byte)(kv.Value * byte.MaxValue));
+
+                foreach (var kv in dpadStates)
+                    if (XboxButtons.TryGetValue(kv.Key, out var dir))
+                        ctrl.SetDPad(dir, kv.Value);
             }
-            foreach (var kv in axisStates)
+            else
             {
-                if (Enum.TryParse<Xbox360Axis>(kv.Key, out var xbAxis))
-                    ctrl.SetAxis(xbAxis, (short)(kv.Value * short.MaxValue));
-                else if (Enum.TryParse<DualShock4Axis>(kv.Key, out var dsAxis))
-                    ctrl.SetAxis(dsAxis, (byte)(Math.Clamp(kv.Value, 0f, 1f) * byte.MaxValue));
-            }
-            foreach (var kv in triggerStates)
-            {
-                if (Enum.TryParse<Xbox360Slider>(kv.Key, out var xbSlider))
-                    ctrl.SetTrigger(xbSlider, (byte)(kv.Value * byte.MaxValue));
-                else if (Enum.TryParse<DualShock4Slider>(kv.Key, out var dsSlider))
-                    ctrl.SetTrigger(dsSlider, (byte)(kv.Value * byte.MaxValue));
-            }
-            foreach (var kv in dpadStates)
-            {
-                if (Enum.TryParse<Xbox360Button>(kv.Key, out var xbButton))
-                    ctrl.SetDPad(xbButton, kv.Value);
-                else if (Enum.TryParse<DualShock4DPadDirection>(kv.Key, out var dsDPad))
-                    ctrl.SetDPad(dsDPad, kv.Value);
+                foreach (var kv in buttonStates)
+                    if (Ds4Buttons.TryGetValue(kv.Key, out var btn))
+                        ctrl.SetButton(btn, kv.Value);
+
+                foreach (var kv in axisStates)
+                    if (Ds4Axes.TryGetValue(kv.Key, out var axis))
+                        ctrl.SetAxis(axis, (byte)(Math.Clamp(kv.Value, 0f, 1f) * byte.MaxValue));
+
+                foreach (var kv in triggerStates)
+                    if (Ds4Triggers.TryGetValue(kv.Key, out var trig))
+                        ctrl.SetTrigger(trig, (byte)(kv.Value * byte.MaxValue));
+
+                foreach (var kv in dpadStates)
+                    if (Enum.TryParse<DualShock4DPadDirection>(kv.Key, true, out var dir))
+                        ctrl.SetDPad(dir, kv.Value);
             }
 
             ctrl.Submit();

--- a/InputToControllerMapper.sln
+++ b/InputToControllerMapper.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -6,8 +5,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", "{10352160-6EF9-4DB2-9E20-24FD8E824AFE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputToControllerMapper", "InputToControllerMapper\InputToControllerMapper.csproj", "{FD25733C-EA84-4040-82DC-144B850564F6}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeadlessControllerEmulator", "HeadlessControllerEmulator\HeadlessControllerEmulator.csproj", "{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}"
-EndProject
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeadlessControllerEmulator", "HeadlessControllerEmulator\HeadlessControllerEmulator.csproj", "{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}"
 EndProject
@@ -18,37 +15,37 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialization.Tests", "Tests\Serialization.Tests\Serialization.Tests.csproj", "{46831B9F-4E1C-485D-B213-8BADF8532F74}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Release|Any CPU.Build.0 = Release|Any CPU
-                {FD25733C-EA84-4040-82DC-144B850564F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {FD25733C-EA84-4040-82DC-144B850564F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {FD25733C-EA84-4040-82DC-144B850564F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {FD25733C-EA84-4040-82DC-144B850564F6}.Release|Any CPU.Build.0 = Release|Any CPU
-                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Release|Any CPU.Build.0 = Release|Any CPU
-                {9ACB542D-17E8-436E-92CF-CEC246151C09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9ACB542D-17E8-436E-92CF-CEC246151C09}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9ACB542D-17E8-436E-92CF-CEC246151C09}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9ACB542D-17E8-436E-92CF-CEC246151C09}.Release|Any CPU.Build.0 = Release|Any CPU
-		{46831B9F-4E1C-485D-B213-8BADF8532F74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{46831B9F-4E1C-485D-B213-8BADF8532F74}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{46831B9F-4E1C-485D-B213-8BADF8532F74}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{46831B9F-4E1C-485D-B213-8BADF8532F74}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{9ACB542D-17E8-436E-92CF-CEC246151C09} = {99DA5C86-234A-427A-8066-6484A743EB69}
-		{46831B9F-4E1C-485D-B213-8BADF8532F74} = {99DA5C86-234A-427A-8066-6484A743EB69}
-	EndGlobalSection
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{10352160-6EF9-4DB2-9E20-24FD8E824AFE}.Release|Any CPU.Build.0 = Release|Any CPU
+{FD25733C-EA84-4040-82DC-144B850564F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FD25733C-EA84-4040-82DC-144B850564F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FD25733C-EA84-4040-82DC-144B850564F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FD25733C-EA84-4040-82DC-144B850564F6}.Release|Any CPU.Build.0 = Release|Any CPU
+{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{D3A991B4-AC54-47C3-A376-790BE5E0D5F3}.Release|Any CPU.Build.0 = Release|Any CPU
+{9ACB542D-17E8-436E-92CF-CEC246151C09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{9ACB542D-17E8-436E-92CF-CEC246151C09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{9ACB542D-17E8-436E-92CF-CEC246151C09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{9ACB542D-17E8-436E-92CF-CEC246151C09}.Release|Any CPU.Build.0 = Release|Any CPU
+{46831B9F-4E1C-485D-B213-8BADF8532F74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{46831B9F-4E1C-485D-B213-8BADF8532F74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{46831B9F-4E1C-485D-B213-8BADF8532F74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{46831B9F-4E1C-485D-B213-8BADF8532F74}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(NestedProjects) = preSolution
+{9ACB542D-17E8-436E-92CF-CEC246151C09} = {99DA5C86-234A-427A-8066-6484A743EB69}
+{46831B9F-4E1C-485D-B213-8BADF8532F74} = {99DA5C86-234A-427A-8066-6484A743EB69}
+EndGlobalSection
 EndGlobal

--- a/InputToControllerMapper/Core/ControllerMappingEngine.cs
+++ b/InputToControllerMapper/Core/ControllerMappingEngine.cs
@@ -14,6 +14,39 @@ namespace InputToControllerMapper
         private readonly IXbox360Controller controller;
         private Profile profile = new Profile();
 
+        private static readonly Dictionary<string, Xbox360Button> ButtonMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = Xbox360Button.A,
+            ["B"] = Xbox360Button.B,
+            ["X"] = Xbox360Button.X,
+            ["Y"] = Xbox360Button.Y,
+            ["Start"] = Xbox360Button.Start,
+            ["Back"] = Xbox360Button.Back,
+            ["LeftThumb"] = Xbox360Button.LeftThumb,
+            ["RightThumb"] = Xbox360Button.RightThumb,
+            ["LeftShoulder"] = Xbox360Button.LeftShoulder,
+            ["RightShoulder"] = Xbox360Button.RightShoulder,
+            ["Up"] = Xbox360Button.Up,
+            ["Down"] = Xbox360Button.Down,
+            ["Left"] = Xbox360Button.Left,
+            ["Right"] = Xbox360Button.Right,
+            ["Guide"] = Xbox360Button.Guide
+        };
+
+        private static readonly Dictionary<string, Xbox360Axis> AxisMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LeftThumbX"] = Xbox360Axis.LeftThumbX,
+            ["LeftThumbY"] = Xbox360Axis.LeftThumbY,
+            ["RightThumbX"] = Xbox360Axis.RightThumbX,
+            ["RightThumbY"] = Xbox360Axis.RightThumbY
+        };
+
+        private static readonly Dictionary<string, Xbox360Slider> TriggerMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LeftTrigger"] = Xbox360Slider.LeftTrigger,
+            ["RightTrigger"] = Xbox360Slider.RightTrigger
+        };
+
         public ControllerMappingEngine()
         {
             client = new ViGEmClient();
@@ -89,21 +122,21 @@ namespace InputToControllerMapper
             switch (action.Element)
             {
                 case ControllerElement.Button:
-                    if (Enum.TryParse(action.Target, true, out Xbox360Button xbButton))
-                        controller.SetButtonState(xbButton, value > 0.5f);
+                    if (ButtonMap.TryGetValue(action.Target, out var btn))
+                        controller.SetButtonState(btn, value > 0.5f);
                     break;
                 case ControllerElement.Axis:
-                    if (Enum.TryParse(action.Target, true, out Xbox360Axis xbAxis))
+                    if (AxisMap.TryGetValue(action.Target, out var axis))
                     {
                         short axisVal = (short)(value * short.MaxValue);
-                        controller.SetAxisValue(xbAxis, axisVal);
+                        controller.SetAxisValue(axis, axisVal);
                     }
                     break;
                 case ControllerElement.Trigger:
-                    if (Enum.TryParse(action.Target, true, out Xbox360Slider xbSlider))
+                    if (TriggerMap.TryGetValue(action.Target, out var trig))
                     {
                         byte trigVal = (byte)(Math.Clamp(value, 0f, 1f) * byte.MaxValue);
-                        controller.SetSliderValue(xbSlider, trigVal);
+                        controller.SetSliderValue(trig, trigVal);
                     }
                     break;
             }

--- a/InputToControllerMapper/VirtualControllerManager.cs
+++ b/InputToControllerMapper/VirtualControllerManager.cs
@@ -2,19 +2,14 @@ using System;
 using Nefarius.ViGEm.Client;
 using Nefarius.ViGEm.Client.Targets.Xbox360;
 using Nefarius.ViGEm.Client.Targets.DualShock4;
+using Core;
 
 namespace InputToControllerMapper
 {
-    public enum VirtualControllerType
-    {
-        Xbox360,
-        DualShock4
-    }
-
     /// <summary>
     /// Simple wrapper that manages either a virtual Xbox 360 or DualShock 4 controller.
     /// </summary>
-    public class VirtualControllerManager : IDisposable
+    public class VirtualControllerManager : IDisposable, IVirtualController
     {
         private readonly ViGEmClient client;
         private IXbox360Controller? xbox;
@@ -106,13 +101,15 @@ namespace InputToControllerMapper
         }
         public void SetDPad(DualShock4DPadDirection dsDPad, bool pressed)
         {
-            ds4?.SetDPadDirection(dsDPad);
+            if (ds4 == null)
+                return;
+            ds4.SetDPadDirection(pressed ? dsDPad : DualShock4DPadDirection.None);
         }
 
         /// <summary>
         /// Sends the prepared report to the driver.
         /// </summary>
-        public void SubmitReport()
+        public void Submit()
         {
             xbox?.SubmitReport();
             ds4?.SubmitReport();


### PR DESCRIPTION
## Summary
- enable nullable for the core project
- add `VirtualControllerType` and property to `IVirtualController`
- implement the interface in `VirtualControllerManager`
- map control names via dictionaries in `MappingEngine`
- update old `ControllerMappingEngine` to use dictionaries
- clean duplicate project from the solution file

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686885f55b648320b46ef11d692806f6